### PR TITLE
Independent X & Y Accelerations

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ If you're feeling adventurous, take a peek at the extra features in the bleeding
 
 - [input_shaper: new print_ringing_tower utility](https://github.com/DangerKlippers/danger-klipper/pull/69)
 
+- [Independent X & Y Acceleration and velocity settings](https://github.com/DangerKlippers/danger-klipper/pull/4)
+
 ## Switch to Danger Klipper
 
 > [!NOTE]

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,12 @@ All dates in this document are approximate.
 
 ## Changes
 
+20240128: `printer.kinematics` now accepts `limited_cartesian` and
+`limited_cartesian` and `limited_corexy` that enables `max_{x,y}_accel` and
+`max_{x,y}_velocity` (only for `limited_cartesian`). In the future, this
+functionality may be moved into the original kinematics module (as optional
+settings).
+
 20240123: The output_pin SET_PIN CYCLE_TIME parameter has been
 removed. Use the new
 [pwm_cycle_time](Config_Reference.md#pwm_cycle_time) module if it is

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -292,21 +292,11 @@ max_z_accel:
 [stepper_z]
 ```
 
-### Cartesian Kinematics with limits for X and Y axes
+### ⚠️ Cartesian Kinematics with limits for X and Y axes
 
 Behaves exactly the as cartesian kinematics, but allows to set a velocity and
-acceleration limit for X and Y axis.
+acceleration limit for X and Y axis. This also makes command [`SET_KINEMATICS_LIMIT`](./G-Codes.md#⚠️-set_kinematics_limit) available to sets these limits at runtime.
 
-If you set accelerations per feature type in the slicer, and have tuned your
-acceleration to get similar resonance amplitudes and level of smoothing on X and
-Y, you may want to enable `scale_xy_accel: true`. This will scale the X and Y
-accelerations by the ratio `M204 acceleration / config.max_accel`. For example,
-if you have `max_accel: 10000` in your config and set in the slicer an
-acceleration of 5000 mm/s² (`M204 S5000`), effective `max_x_accel` and
-`max_y_accel` values will be halved compared to their original values set in the
-`[printer]` config. Otherwise, with `scale_xy_accel: false` (the default) they
-behave as machine limits, like `max_z_accel` and `max_z_velocity` always do.
-Gcode velocities under the limits are never scaled per axis and stay isotropic.
 
 ```
 [printer]
@@ -338,28 +328,34 @@ max_y_accel:
 max_z_accel:
 # See cartesian above.
 max_accel:
-#   In order to get maximum acceleration gains on diagonals, this should be
-#   equal or greater than the hypotenuse (sqrt(x*x + y*y)) of max_x_accel and
-#   max_y_accel.
-scale_xy_accel:
-#   If scale_xy_accel is False, `max_accel`, set by M204 or SET_VELOCITY_LIMIT,
-#   acts as a third limit. This means that moves with an acceleration lower
-#   than max_x_accel and max_y_accel, have no per-axis limits applied. When set
-#   to True, max_x_accel and max_y_accel are scaled by the ratio of the
-#   acceleration set at runtime and the max_accel value from the config. Then
-#   the actual acceleration will always depend on the orientation.
+# See cartesian above.
+scale_xy_accel: False
+#   When true, scales the XY limits by the current tool head acceleration.
+#   The factor is: slicer accel / hypot(max_x_accel, max_y_accel).
+#   See below.
 ```
 
-### Linear Delta Kinematics
+If scale_xy_accel is `False`, the acceleration set by `max_accel`, M204 or
+SET_VELOCITY_LIMIT, acts as a third limit. In that case, this module doesn't
+apply limitations on moves having an acceleration lower than `max_x_accel`` and
+`max_y_accel`. When scale_xy_accel is `True`, `max_x_accel` and `max_y_accel`
+are scaled by the ratio of the dynamically set acceleration and the hypotenuse
+of max_x_accel and `max_y_accel`, as reported from `SET_KINEMATICS_LIMIT`. This
+implies that the actual acceleration will always depend on the direction. For
+example, these settings:
 
-See [example-delta.cfg](../config/example-delta.cfg) for an example
-linear delta kinematics config file. See the
-[delta calibrate guide](Delta_Calibrate.md) for information on
-calibration.
+```
+[printer]
+max_x_accel: 12000
+max_y_accel: 9000
+scale_xy_accel: true
+```
 
-Only parameters specific to linear delta printers are described here -
-see [common kinematic settings](#common-kinematic-settings) for
-available parameters.
+`SET_KINEMATICS_LIMIT` will report a maximum acceleration of 15000 mm/s^2 on 37°
+diagonals. If the slicer emit `M204 S3000` (3000 mm/s^2 accel). On these 37° and
+143° diagonals, the toolhead will accelerate at 3000 mm/s^2. On the X axis, the
+acceleration will be  12000 * 3000 / 15000 = 2400 mm/s^2, and 18000 mm/s^2 for
+pure Y moves.
 
 ```
 [printer]
@@ -546,7 +542,7 @@ max_z_accel:
 [stepper_z]
 ```
 
-### :warning: CoreXY Kinematics with limits for X and Y axes
+### ⚠️ CoreXY Kinematics with limits for X and Y axes
 
 Behaves exactly the as CoreXY kinematics, but allows to set a acceleration limit
 for X and Y axis.
@@ -554,24 +550,12 @@ for X and Y axis.
 There is no velocity limits for X and Y, since on a CoreXY the pull-out velocity
 are identical on both axes.
 
-If you set accelerations per feature type in the slicer, and have tuned your
-acceleration to get similar resonance amplitudes and level of smoothing on X and
-Y, you may want to enable `scale_xy_accel: true`. This will scale the X and Y
-accelerations by the ratio `M204 acceleration / config.max_accel`. For example,
-if you have `max_accel: 10000` in your config and set in the slicer an
-acceleration of 5000 mm/s² (`M204 S5000`), effective `max_x_accel` and
-`max_y_accel` values will be halved compared to their original values set in the
-`[printer]` config. Otherwise, with `scale_xy_accel: false` (the default) they
-behave as machine limits, like `max_z_accel` always does.
-
-!!! warning
-    Note that there are **print quality concerns** with anisotropic accelerations and velocities. This is the main reason that previous attempts to upstream something like this failed.
 
 ```
 [printer]
 kinematics: limited_corexy
 max_z_velocity:
-#   See cartesian above.
+#   See CoreXY above.
 max_x_accel:
 #   This sets the maximum acceleration (in mm/s^2) of movement along
 #   the x axis. It limits the acceleration of the x stepper motor. The
@@ -581,18 +565,12 @@ max_y_accel:
 #   the y axis. It limits the acceleration of the y stepper motor. The
 #   default is to use max_accel for max_y_accel.
 max_z_accel:
-# See cartesian above.
+# See CoreXY above.
 max_accel:
-#   In order to get maximum acceleration gains on diagonals, this should be
-#   equal or greater than the hypotenuse (sqrt(x*x + y*y)) of max_x_accel and
-#   max_y_accel.
+# See CoreXY above..
 scale_xy_accel:
-#   If scale_xy_accel is False, `max_accel`, set by M204 or SET_VELOCITY_LIMIT,
-#   acts as a third limit. This means that moves with an acceleration lower
-#   than max_x_accel and max_y_accel, have no per-axis limits applied. When set
-#   to True, max_x_accel and max_y_accel are scaled by the ratio of the
-#   acceleration set at runtime and the max_accel value from the config. Then
-#   the actual acceleration will always depend on the orientation.
+#   When True, scales the XY limits by the current tool head acceleration.
+#   The factor is: slicer accel / max(max_x_accel, max_y_accel).
 ```
 
 ### CoreXZ Kinematics

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -292,6 +292,64 @@ max_z_accel:
 [stepper_z]
 ```
 
+### Cartesian Kinematics with limits for X and Y axes
+
+Behaves exactly the as cartesian kinematics, but allows to set a velocity and
+acceleration limit for X and Y axis.
+
+If you set accelerations per feature type in the slicer, and have tuned your
+acceleration to get similar resonance amplitudes and level of smoothing on X and
+Y, you may want to enable `scale_xy_accel: true`. This will scale the X and Y
+accelerations by the ratio `M204 acceleration / config.max_accel`. For example,
+if you have `max_accel: 10000` in your config and set in the slicer an
+acceleration of 5000 mm/s² (`M204 S5000`), effective `max_x_accel` and
+`max_y_accel` values will be halved compared to their original values set in the
+`[printer]` config. Otherwise, with `scale_xy_accel: false` (the default) they
+behave as machine limits, like `max_z_accel` and `max_z_velocity` always do.
+Gcode velocities under the limits are never scaled per axis and stay isotropic.
+
+```
+[printer]
+kinematics: limited_cartesian
+max_x_velocity:
+#   This sets the maximum velocity (in mm/s) of movement along the x
+#   axis. This setting can be used to restrict the maximum speed of
+#   the x stepper motor. The default is to use max_velocity for
+#   max_x_velocity.
+max_y_velocity:
+#   This sets the maximum velocity (in mm/s) of movement along the y
+#   axis. This setting can be used to restrict the maximum speed of
+#   the y stepper motor. The default is to use max_velocity for
+#   max_x_velocity.
+max_z_velocity:
+#   See cartesian above.
+max_velocity:
+#   In order to get maximum velocity gains on diagonals, this should be equal or
+#   greater than the hypotenuse (sqrt(x*x + y*y)) of max_x_velocity and
+#   max_y_velocity.
+max_x_accel:
+#   This sets the maximum acceleration (in mm/s^2) of movement along
+#   the x axis. It limits the acceleration of the x stepper motor. The
+#   default is to use max_accel for max_x_accel.
+max_y_accel:
+#   This sets the maximum acceleration (in mm/s^2) of movement along
+#   the y axis. It limits the acceleration of the y stepper motor. The
+#   default is to use max_accel for max_y_accel.
+max_z_accel:
+# See cartesian above.
+max_accel:
+#   In order to get maximum acceleration gains on diagonals, this should be
+#   equal or greater than the hypotenuse (sqrt(x*x + y*y)) of max_x_accel and
+#   max_y_accel.
+scale_xy_accel:
+#   If scale_xy_accel is False, `max_accel`, set by M204 or SET_VELOCITY_LIMIT,
+#   acts as a third limit. This means that moves with an acceleration lower
+#   than max_x_accel and max_y_accel, have no per-axis limits applied. When set
+#   to True, max_x_accel and max_y_accel are scaled by the ratio of the
+#   acceleration set at runtime and the max_accel value from the config. Then
+#   the actual acceleration will always depend on the orientation.
+```
+
 ### Linear Delta Kinematics
 
 See [example-delta.cfg](../config/example-delta.cfg) for an example
@@ -486,6 +544,55 @@ max_z_accel:
 # The stepper_z section is used to describe the stepper controlling
 # the Z axis.
 [stepper_z]
+```
+
+### :warning: CoreXY Kinematics with limits for X and Y axes
+
+Behaves exactly the as CoreXY kinematics, but allows to set a acceleration limit
+for X and Y axis.
+
+There is no velocity limits for X and Y, since on a CoreXY the pull-out velocity
+are identical on both axes.
+
+If you set accelerations per feature type in the slicer, and have tuned your
+acceleration to get similar resonance amplitudes and level of smoothing on X and
+Y, you may want to enable `scale_xy_accel: true`. This will scale the X and Y
+accelerations by the ratio `M204 acceleration / config.max_accel`. For example,
+if you have `max_accel: 10000` in your config and set in the slicer an
+acceleration of 5000 mm/s² (`M204 S5000`), effective `max_x_accel` and
+`max_y_accel` values will be halved compared to their original values set in the
+`[printer]` config. Otherwise, with `scale_xy_accel: false` (the default) they
+behave as machine limits, like `max_z_accel` always does.
+
+!!! warning
+    Note that there are **print quality concerns** with anisotropic accelerations and velocities. This is the main reason that previous attempts to upstream something like this failed.
+
+```
+[printer]
+kinematics: limited_corexy
+max_z_velocity:
+#   See cartesian above.
+max_x_accel:
+#   This sets the maximum acceleration (in mm/s^2) of movement along
+#   the x axis. It limits the acceleration of the x stepper motor. The
+#   default is to use max_accel for max_x_accel.
+max_y_accel:
+#   This sets the maximum acceleration (in mm/s^2) of movement along
+#   the y axis. It limits the acceleration of the y stepper motor. The
+#   default is to use max_accel for max_y_accel.
+max_z_accel:
+# See cartesian above.
+max_accel:
+#   In order to get maximum acceleration gains on diagonals, this should be
+#   equal or greater than the hypotenuse (sqrt(x*x + y*y)) of max_x_accel and
+#   max_y_accel.
+scale_xy_accel:
+#   If scale_xy_accel is False, `max_accel`, set by M204 or SET_VELOCITY_LIMIT,
+#   acts as a third limit. This means that moves with an acceleration lower
+#   than max_x_accel and max_y_accel, have no per-axis limits applied. When set
+#   to True, max_x_accel and max_y_accel are scaled by the ratio of the
+#   acceleration set at runtime and the max_accel value from the config. Then
+#   the actual acceleration will always depend on the orientation.
 ```
 
 ### CoreXZ Kinematics

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1370,6 +1370,19 @@ printer config file. See the
 [printer config section](Config_Reference.md#printer) for a
 description of each parameter.
 
+#### ⚠️ SET_KINEMATICS_LIMIT
+
+`SET_KINEMATICS_LIMIT [<X,Y,Z>_ACCEL=<value>] [<X,Y,Z>_VELOCITY=<value>]
+[SCALE=<0:1>]`: change the per-axis limits.
+
+This command is only available when `kinematics` is set to either
+[`limited_cartesian`](./Config_Reference.md#⚠️-cartesian-kinematics-with-limits-for-x-and-y-axes)
+or
+[`limited_corexy`](./Config_Reference.md#⚠️-corexy-kinematics-with-limits-for-x-and-y-axes).
+The velocity argument is not available on CoreXY. With no arguments, this
+command responds with the movement direction with the most acceleration or
+velocity.
+
 ### [tuning_tower]
 
 The tuning_tower module is automatically loaded.

--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -6,6 +6,7 @@
 import math
 import os
 import time
+from contextlib import contextmanager
 from . import shaper_calibrate
 
 
@@ -52,6 +53,73 @@ def _parse_axis(gcmd, raw_axis):
     return TestAxis(vib_dir=(dir_x, dir_y))
 
 
+@contextmanager
+def suspend_limits(printer, max_accel, max_velocity, input_shaping):
+    # Override maximum acceleration and acceleration to
+    # deceleration based on the maximum test frequency
+    gcode = printer.lookup_object("gcode")
+    input_shaper = printer.lookup_object("input_shaper", None)
+    if input_shaper is not None and not input_shaping:
+        input_shaper.disable_shaping()
+        gcode.respond_info("Disabled [input_shaper] for resonance testing")
+    else:
+        input_shaper = None
+    toolhead = printer.lookup_object("toolhead")
+    systime = printer.get_reactor().monotonic()
+    toolhead_info = toolhead.get_status(systime)
+    old_max_accel = toolhead_info["max_accel"]
+    old_max_accel_to_decel = toolhead_info["max_accel_to_decel"]
+    old_max_velocity = toolhead_info["max_velocity"]
+    gcode.run_script_from_command(
+        "SET_VELOCITY_LIMIT ACCEL=%.3f ACCEL_TO_DECEL=%.3f VELOCITY=%.3f"
+        % (max_accel, max_accel, max_velocity)
+    )
+    kin = toolhead.get_kinematics()
+    old_max_velocities = getattr(kin, "max_velocities", None)
+    if old_max_velocities is not None:
+        kin.max_velocities = [
+            max_velocity,
+            max_velocity,
+            old_max_velocities[-1],
+        ]
+    old_max_accels = getattr(kin, "max_accels", None)
+    if old_max_accels is not None:
+        kin.max_accels = [max_accel, max_accel, old_max_accels[-1]]
+    # FIXME: could be cleaner if limited_corexy were using the same format than
+    # limited_cartesian
+    old_max_x_accel = getattr(kin, "max_x_accel", None)
+    if old_max_x_accel is not None:
+        kin.max_x_accel = max_accel
+    old_max_y_accel = getattr(kin, "max_y_accel", None)
+    if old_max_y_accel is not None:
+        kin.max_y_accel = max_accel
+    old_scale_per_axis = getattr(kin, "scale_per_axis", None)
+    if old_scale_per_axis is not None:
+        kin.scale_per_axis = False
+    try:
+        yield
+    finally:
+        # Restore input shaper if it was disabled for resonance testing
+        if input_shaper is not None:
+            input_shaper.enable_shaping()
+            gcode.respond_info("Re-enabled [input_shaper]")
+        # Restore the original acceleration values
+        gcode.run_script_from_command(
+            "SET_VELOCITY_LIMIT ACCEL=%.3f ACCEL_TO_DECEL=%.3f VELOCITY=%.3f"
+            % (old_max_accel, old_max_accel_to_decel, old_max_velocity)
+        )
+        if old_max_velocities is not None:
+            kin.max_velocities = old_max_velocities
+        if old_max_accels is not None:
+            kin.max_accels = old_max_accels
+        if old_max_x_accel is not None:
+            kin.max_x_accel = old_max_x_accel
+        if old_max_y_accel is not None:
+            kin.max_y_accel = old_max_y_accel
+        if old_scale_per_axis is not None:
+            kin.scale_per_axis = old_scale_per_axis
+
+
 class VibrationPulseTest:
     def __init__(self, config):
         self.printer = config.get_printer()
@@ -85,27 +153,19 @@ class VibrationPulseTest:
         )
 
     def run_test(self, axis, gcmd):
+        with suspend_limits(
+            self.printer,
+            self.freq_end * self.accel_per_hz + 10.0,
+            self.accel_per_hz * 0.25 + 1.0,
+            gcmd.get_int("INPUT_SHAPING", 0),
+        ):
+            self._run_test(axis, gcmd)
+
+    def _run_test(self, axis, gcmd):
         toolhead = self.printer.lookup_object("toolhead")
         X, Y, Z, E = toolhead.get_position()
         sign = 1.0
         freq = self.freq_start
-        # Override maximum acceleration and acceleration to
-        # deceleration based on the maximum test frequency
-        systime = self.printer.get_reactor().monotonic()
-        toolhead_info = toolhead.get_status(systime)
-        old_max_accel = toolhead_info["max_accel"]
-        old_max_accel_to_decel = toolhead_info["max_accel_to_decel"]
-        max_accel = self.freq_end * self.accel_per_hz
-        self.gcode.run_script_from_command(
-            "SET_VELOCITY_LIMIT ACCEL=%.3f ACCEL_TO_DECEL=%.3f"
-            % (max_accel, max_accel)
-        )
-        input_shaper = self.printer.lookup_object("input_shaper", None)
-        if input_shaper is not None and not gcmd.get_int("INPUT_SHAPING", 0):
-            input_shaper.disable_shaping()
-            gcmd.respond_info("Disabled [input_shaper] for resonance testing")
-        else:
-            input_shaper = None
         gcmd.respond_info("Testing frequency %.0f Hz" % (freq,))
         while freq <= self.freq_end + 0.000001:
             t_seg = 0.25 / freq
@@ -125,15 +185,6 @@ class VibrationPulseTest:
             freq += 2.0 * t_seg * self.hz_per_sec
             if math.floor(freq) > math.floor(old_freq):
                 gcmd.respond_info("Testing frequency %.0f Hz" % (freq,))
-        # Restore the original acceleration values
-        self.gcode.run_script_from_command(
-            "SET_VELOCITY_LIMIT ACCEL=%.3f ACCEL_TO_DECEL=%.3f"
-            % (old_max_accel, old_max_accel_to_decel)
-        )
-        # Restore input shaper if it was disabled for resonance testing
-        if input_shaper is not None:
-            input_shaper.enable_shaping()
-            gcmd.respond_info("Re-enabled [input_shaper]")
 
 
 class ResonanceTester:

--- a/klippy/kinematics/limited_cartesian.py
+++ b/klippy/kinematics/limited_cartesian.py
@@ -1,0 +1,143 @@
+# Code for handling the kinematics of cartesian robots
+# with per-axis limits for velocity and acceleration
+#
+# Copyright (C) 2020-2021  Mael Kerbiriou <piezo.wdimd@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+#
+# Usage:
+# Copying this file under `klipper/klippy/kinematics/` should be enough (click
+# the `raw` button on github, then save as)
+# Then your config's [printer] should look like:
+# [printer]
+# kinematics: limited_cartesian
+# max_velocity: 875
+# max_x_velocity: 750
+# max_y_velocity: 450
+# max_z_velocity: 5
+# max_accel: 15000
+# max_x_accel: 12000
+# max_y_accel: 9000
+# max_z_accel: 100
+# scale_xy_accel: [True/False, default False]
+#
+# max_accel/velocity are usually the hypotenuses of X and Y values, For example:
+# with max_x_accel = 15000 and max_y_accel = 8000, the recommended value is
+# max_accel = 17000.
+#
+# If scale_xy_accel is False, `max_accel`, set by M204 or SET_VELOCITY_LIMIT,
+# acts as a third limit. This means that moves with an acceleration lower than
+# max_x_accel and max_y_accel, have no per-axis limits applied. When True,
+# max_x_accel and max_y_accel are scaled by the ratio of the dynamically set
+# acceleration and the max_accel value from the config. This means that the
+# actual acceleration will always depend on the direction.
+
+import sys
+from math import hypot, atan2, pi
+
+from . import cartesian
+
+EPSILON = sys.float_info.epsilon
+SQRT2 = hypot(1.0, 1.0)
+
+
+class LimitedCartKinematics(cartesian.CartKinematics):
+    def __init__(self, toolhead, config):
+        cartesian.CartKinematics.__init__(self, toolhead, config)
+        self.toolhead = toolhead
+        # Setup y axis limits
+        max_velocity, max_accel = toolhead.get_max_velocity()
+        self.config_max_velocity = max_velocity
+        self.config_max_accel = max_accel
+        self.max_velocities = [
+            config.getfloat(
+                f"max_{ax}_velocity",
+                SQRT2 * max_velocity,
+                above=0.0,
+                maxval=max_velocity,
+            )
+            for ax in "xyz"
+        ]
+        self.max_accels = [
+            config.getfloat(
+                f"max_{ax}_accel", max_accel, above=0.0, maxval=max_accel
+            )
+            for ax in "xyz"
+        ]
+        self.scale_per_axis = config.getboolean("scale_xy_accel", False)
+        config.get_printer().lookup_object("gcode").register_command(
+            "SET_KINEMATICS_LIMIT",
+            self.cmd_SET_KINEMATICS_LIMIT,
+            desc=self.cmd_SET_KINEMATICS_LIMIT_help,
+        )
+
+    cmd_SET_KINEMATICS_LIMIT_help = "Set/get cartesian per axis velocity limits"
+
+    def cmd_SET_KINEMATICS_LIMIT(self, gcmd):
+        config_max_velocity = self.config_max_velocity
+        config_max_accel = self.config_max_accel
+        self.max_velocities = [
+            gcmd.get_float(
+                f"{ax}_VELOCITY", max_v, above=0.0, maxval=config_max_velocity
+            )
+            for max_v, ax in zip(self.max_velocities, "XYZ")
+        ]
+        self.max_accels = [
+            gcmd.get_float(
+                f"{ax}_ACCEL", max_a, above=0.0, maxval=config_max_accel
+            )
+            for max_a, ax in zip(self.max_accels, "XYZ")
+        ]
+        self.scale_per_axis = bool(
+            gcmd.get_int("SCALE", self.scale_per_axis, minval=0, maxval=1)
+        )
+
+        if gcmd.get_command_parameters():
+            return
+        msg = [
+            f"x,y,z max_velocities: {self.max_velocities!r}",
+            f"x,y,z max_accels: {self.max_accels!r}",
+        ]
+        if self.scale_per_axis:
+            msg.append(
+                "Per axis accelerations limits scale with current acceleration."
+            )
+        else:
+            msg.append(
+                "Per axis accelerations limits are independent of current acceleration."
+            )
+        max_velocity = hypot(self.max_velocities[0], self.max_velocities[1])
+        max_v_angle = atan2(self.max_velocities[1], self.max_velocities[0])
+        msg.append(
+            f"Maximum XY velocity of {max_velocity:.1f} mm/s reached on {max_v_angle * 180 / pi:.0f}° diagonals."
+        )
+        max_accel = hypot(self.max_accels[0], self.max_accels[1])
+        max_a_angle = atan2(self.max_accels[1], self.max_accels[0])
+        msg.append(
+            f"Maximum XY acceleration of {max_accel:.1f} mm/s reached on {max_a_angle * 180 / pi:.0f}° diagonals."
+        )
+        gcmd.respond_info("\n".join(msg), log=False)
+
+    def check_move(self, move):
+        if not move.is_kinematic_move:
+            return
+        self._check_endstops(move)
+        x_r, y_r, z_r = move.axes_r[:3]
+        x_max_v, y_max_v, z_max_v = self.max_velocities
+        x_max_a, y_max_a, z_max_a = self.max_accels
+        x_r = max(abs(x_r), EPSILON)
+        y_r = max(abs(y_r), EPSILON)
+        max_v = min(x_max_v / x_r, y_max_v / y_r)
+        max_a = min(x_max_a / x_r, y_max_a / y_r)
+        if self.scale_per_axis:
+            _, toolhead_accel = self.toolhead.get_max_velocity()
+            max_a *= toolhead_accel / self.config_max_accel
+        if z_r:
+            z_r = abs(z_r)
+            max_v = min(max_v, z_max_v / z_r)
+            max_a = min(max_a, z_max_a / z_r)
+        move.limit_speed(max_v, max_a)
+
+
+def load_kinematics(toolhead, config):
+    return LimitedCartKinematics(toolhead, config)

--- a/klippy/kinematics/limited_corexy.py
+++ b/klippy/kinematics/limited_corexy.py
@@ -1,0 +1,128 @@
+# Code for handling the kinematics of corexy robots
+# with per-axis limits for acceleration
+#
+# Copyright (C) 2020-2021  Mael Kerbiriou <piezo.wdimd@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+#
+# Usage:
+# Copying this file under `klipper/klippy/kinematics/` should be enough (click
+# the `raw` button on github, then save as)
+# Then your config's [printer] should look like:
+# [printer]
+# kinematics: limited_corexy
+# max_velocity: [141% original value]
+# max_z_velocity: [untouched]
+# max_accel: [max_x_accel, or less if you want to clip the per-axis limiting]
+# max_x_accel: [empirically determined, max_accel taken if omitted]
+# max_y_accel: [empirically determined, less than max_x_accel because of gantry mass]
+# max_z_accel: [untouched]
+# scale_xy_accel: [True/False, default False]
+#
+# If scale_xy_accel is False, `max_accel`, set by M204 or SET_VELOCITY_LIMIT,
+# acts as a third limit. This means that moves with an acceleration lower than
+# max_x_accel and max_y_accel, have no per-axis limits applied. When True,
+# max_x_accel and max_y_accel are scaled by the ratio of the dynamically set
+# acceleration and the max_accel value from the config. This means that the
+# actual acceleration will always depend on the direction.
+#
+# Derivation of the formulae described in this notebook:
+# https://github.com/Piezoid/klipper/blob/work-peraxis/docs/PerAxisLimits.ipynb
+
+from . import corexy
+from math import sqrt, atan2, pi
+
+
+class LimitedCoreXYKinematics(corexy.CoreXYKinematics):
+    def __init__(self, toolhead, config):
+        corexy.CoreXYKinematics.__init__(self, toolhead, config)
+        self.toolhead = toolhead
+        # Setup x/y axis limits
+        max_velocity, max_accel = toolhead.get_max_velocity()
+        self.config_max_accel = max_accel
+        self.max_x_accel = config.getfloat("max_x_accel", max_accel, above=0)
+        self.max_y_accel = config.getfloat("max_y_accel", max_accel, above=0)
+        self.scale_per_axis = config.getboolean("scale_xy_accel", False)
+        config.get_printer().lookup_object("gcode").register_command(
+            "SET_KINEMATICS_LIMIT",
+            self.cmd_SET_KINEMATICS_LIMIT,
+            desc=self.cmd_SET_KINEMATICS_LIMIT_help,
+        )
+
+    cmd_SET_KINEMATICS_LIMIT_help = "Set/get CoreXY per axis velocity limits"
+
+    def cmd_SET_KINEMATICS_LIMIT(self, gcmd):
+        config_max_accel = self.config_max_accel
+        self.max_x_accel = gcmd.get_float(
+            "X_ACCEL", self.max_x_accel, above=0.0, maxval=config_max_accel
+        )
+        self.max_y_accel = gcmd.get_float(
+            "Y_ACCEL", self.max_y_accel, above=0.0, maxval=config_max_accel
+        )
+        self.max_z_accel = gcmd.get_float(
+            "Z_ACCEL", self.max_z_accel, above=0.0, maxval=config_max_accel
+        )
+        self.scale_per_axis = bool(
+            gcmd.get_int("SCALE", self.scale_per_axis, minval=0, maxval=1)
+        )
+        max_accels = (
+            self.max_x_accel,
+            self.max_y_accel,
+            self.max_z_accel,
+        )
+
+        if gcmd.get_command_parameters():
+            return
+        msg = [f"x,y,z max_accels: {max_accels!r}"]
+        if self.scale_per_axis:
+            msg.append(
+                "Per axis accelerations limits scale with current acceleration."
+            )
+        else:
+            msg.append(
+                "Per axis accelerations limits are independent of current acceleration."
+            )
+        min_accel = 1 / sqrt(
+            self.max_x_accel ** (-2) + self.max_y_accel ** (-2)
+        )
+        min_angle = atan2(self.max_x_accel, self.max_y_accel)
+        msg.append(
+            f"Minimum XY acceleration of {min_accel:.0f} mm/s² reached on {180 * min_angle / pi:.0f}° diagonals."
+        )
+        gcmd.respond_info("\n".join(msg))
+
+    def check_move(self, move):
+        if not move.is_kinematic_move:
+            return
+        self._check_endstops(move)
+        toolhead = move.toolhead
+        max_v = toolhead.max_velocity
+        max_a = toolhead.max_accel
+        move_d = move.move_d
+        x, y, z = move.axes_d[:3]
+        ab_linf = max(abs(x + y), abs(x - y))
+        if ab_linf > 0:
+            max_v *= move_d / ab_linf
+            x_o_a = x / self.max_x_accel
+            y_o_a = y / self.max_y_accel
+            if self.scale_per_axis:
+                _, toolhead_accel = self.toolhead.get_max_velocity()
+                max_a *= (
+                    toolhead_accel
+                    * move_d
+                    / (
+                        max(abs(x_o_a + y_o_a), abs(x_o_a - y_o_a))
+                        * self.config_max_accel
+                    )
+                )
+            else:
+                max_a = move_d / max(abs(x_o_a + y_o_a), abs(x_o_a - y_o_a))
+        if z:
+            z_ratio = move_d / abs(z)
+            max_v = min(max_v, self.max_z_velocity * z_ratio)
+            max_a = min(max_a, self.max_z_accel * z_ratio)
+        move.limit_speed(max_v, max_a)
+
+
+def load_kinematics(toolhead, config):
+    return LimitedCoreXYKinematics(toolhead, config)

--- a/klippy/kinematics/limited_corexy.py
+++ b/klippy/kinematics/limited_corexy.py
@@ -1,4 +1,4 @@
-# Code for handling the kinematics of corexy robots
+# Limits XY accelerations on corexy robots
 # with per-axis limits for acceleration
 #
 # Copyright (C) 2020-2021  Mael Kerbiriou <piezo.wdimd@gmail.com>
@@ -13,33 +13,32 @@
 # kinematics: limited_corexy
 # max_velocity: [141% original value]
 # max_z_velocity: [untouched]
-# max_accel: [max_x_accel, or less if you want to clip the per-axis limiting]
+# max_accel: [default acceleration at startup]
 # max_x_accel: [empirically determined, max_accel taken if omitted]
 # max_y_accel: [empirically determined, less than max_x_accel because of gantry mass]
 # max_z_accel: [untouched]
 # scale_xy_accel: [True/False, default False]
 #
-# If scale_xy_accel is False, `max_accel`, set by M204 or SET_VELOCITY_LIMIT,
-# acts as a third limit. This means that moves with an acceleration lower than
-# max_x_accel and max_y_accel, have no per-axis limits applied. When True,
-# max_x_accel and max_y_accel are scaled by the ratio of the dynamically set
-# acceleration and the max_accel value from the config. This means that the
-# actual acceleration will always depend on the direction.
-#
-# Derivation of the formulae described in this notebook:
-# https://github.com/Piezoid/klipper/blob/work-peraxis/docs/PerAxisLimits.ipynb
+# If scale_xy_accel is False, `max_accel`, set by M204 or
+# SET_VELOCITY_LIMIT, acts as a third limit. This means that moves with an
+# acceleration lower than max_x_accel and max_y_accel, have no per-axis
+# limits applied. When True, max_x_accel and max_y_accel are scaled by the
+# ratio of the dynamically set acceleration and the acceleration of the
+# fastest axis (usually max_x_accel). This means that the actual
+# acceleration will always depend on the direction.
 
+from sys import float_info
 from . import corexy
 from math import sqrt, atan2, pi
+
+EPSILON = 2 * float_info.epsilon
 
 
 class LimitedCoreXYKinematics(corexy.CoreXYKinematics):
     def __init__(self, toolhead, config):
         corexy.CoreXYKinematics.__init__(self, toolhead, config)
-        self.toolhead = toolhead
         # Setup x/y axis limits
-        max_velocity, max_accel = toolhead.get_max_velocity()
-        self.config_max_accel = max_accel
+        _, max_accel = toolhead.get_max_velocity()
         self.max_x_accel = config.getfloat("max_x_accel", max_accel, above=0)
         self.max_y_accel = config.getfloat("max_y_accel", max_accel, above=0)
         self.scale_per_axis = config.getboolean("scale_xy_accel", False)
@@ -52,15 +51,14 @@ class LimitedCoreXYKinematics(corexy.CoreXYKinematics):
     cmd_SET_KINEMATICS_LIMIT_help = "Set/get CoreXY per axis velocity limits"
 
     def cmd_SET_KINEMATICS_LIMIT(self, gcmd):
-        config_max_accel = self.config_max_accel
         self.max_x_accel = gcmd.get_float(
-            "X_ACCEL", self.max_x_accel, above=0.0, maxval=config_max_accel
+            "X_ACCEL", self.max_x_accel, above=0.0
         )
         self.max_y_accel = gcmd.get_float(
-            "Y_ACCEL", self.max_y_accel, above=0.0, maxval=config_max_accel
+            "Y_ACCEL", self.max_y_accel, above=0.0
         )
         self.max_z_accel = gcmd.get_float(
-            "Z_ACCEL", self.max_z_accel, above=0.0, maxval=config_max_accel
+            "Z_ACCEL", self.max_z_accel, above=0.0
         )
         self.scale_per_axis = bool(
             gcmd.get_int("SCALE", self.scale_per_axis, minval=0, maxval=1)
@@ -95,25 +93,20 @@ class LimitedCoreXYKinematics(corexy.CoreXYKinematics):
         if not move.is_kinematic_move:
             return
         self._check_endstops(move)
-        toolhead = move.toolhead
-        max_v = toolhead.max_velocity
-        max_a = toolhead.max_accel
+        max_v, max_a = move.toolhead.get_max_velocity()
         move_d = move.move_d
         x, y, z = move.axes_d[:3]
         ab_linf = max(abs(x + y), abs(x - y))
-        if ab_linf > 0:
+        if ab_linf > EPSILON:
             max_v *= move_d / ab_linf
-            x_o_a = x / self.max_x_accel
-            y_o_a = y / self.max_y_accel
+            max_x_accel = self.max_x_accel
+            max_y_accel = self.max_y_accel
+            x_o_a = x / max_x_accel
+            y_o_a = y / max_y_accel
             if self.scale_per_axis:
-                _, toolhead_accel = self.toolhead.get_max_velocity()
-                max_a *= (
-                    toolhead_accel
-                    * move_d
-                    / (
-                        max(abs(x_o_a + y_o_a), abs(x_o_a - y_o_a))
-                        * self.config_max_accel
-                    )
+                max_a *= move_d / (
+                    max(abs(x_o_a + y_o_a), abs(x_o_a - y_o_a))
+                    * max(max_x_accel, max_y_accel)
                 )
             else:
                 max_a = move_d / max(abs(x_o_a + y_o_a), abs(x_o_a - y_o_a))

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -19,7 +19,7 @@ class Move:
         self.start_pos = tuple(start_pos)
         self.end_pos = tuple(end_pos)
         self.accel = toolhead.max_accel
-        self.junction_deviation = toolhead.junction_deviation
+        self.equilateral_corner_v2 = toolhead.equilateral_corner_v2
         self.timing_callbacks = []
         velocity = min(speed, toolhead.max_velocity)
         self.is_kinematic_move = True
@@ -96,8 +96,8 @@ class Move:
         )
         # Apply limits
         self.max_start_v2 = min(
-            R_jd * self.junction_deviation * self.accel,
-            R_jd * prev_move.junction_deviation * prev_move.accel,
+            R_jd * self.equilateral_corner_v2,
+            R_jd * prev_move.equilateral_corner_v2,
             move_centripetal_v2,
             prev_move_centripetal_v2,
             extruder_v2,
@@ -267,7 +267,7 @@ class ToolHead:
         self.square_corner_velocity = config.getfloat(
             "square_corner_velocity", 5.0, minval=0.0
         )
-        self.junction_deviation = 0.0
+        self.equilateral_corner_v2 = 0.0
         self._calc_junction_deviation()
         # Input stall detection
         self.check_stall_time = 0.0
@@ -728,7 +728,7 @@ class ToolHead:
 
     def _calc_junction_deviation(self):
         scv2 = self.square_corner_velocity**2
-        self.junction_deviation = scv2 * (math.sqrt(2.0) - 1.0) / self.max_accel
+        self.equilateral_corner_v2 = scv2 * (math.sqrt(2.0) - 1.0)
         self.max_accel_to_decel = min(
             self.requested_accel_to_decel, self.max_accel
         )

--- a/scripts/motan/analyzers.py
+++ b/scripts/motan/analyzers.py
@@ -244,6 +244,7 @@ class GenKinematicPosition:
         stepper = name_parts[1]
         status = self.amanager.get_initial_status()
         kin = status["configfile"]["settings"]["printer"]["kinematics"]
+        kin = kin.removeprefix('limited_')
         if kin not in ["cartesian", "corexy"]:
             raise amanager.error("Unsupported kinematics '%s'" % (kin,))
         if stepper not in ["stepper_x", "stepper_y", "stepper_z"]:

--- a/test/klippy/limited_cartesian.cfg
+++ b/test/klippy/limited_cartesian.cfg
@@ -1,0 +1,68 @@
+[stepper_x]
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PE5
+position_endstop: 0
+position_max: 200
+
+[stepper_y]
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PJ1
+position_endstop: 0
+position_max: 200
+
+[stepper_z]
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PD3
+position_endstop: 0.5
+position_max: 200
+
+[extruder]
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 33.500
+nozzle_diameter: 0.500
+filament_diameter: 3.500
+heater_pin: PB4
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK5
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 210
+
+[heater_bed]
+heater_pin: PH5
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK6
+control: watermark
+min_temp: 0
+max_temp: 110
+
+[mcu]
+serial: /dev/ttyACM0
+
+[printer]
+kinematics: limited_cartesian
+max_velocity: 500
+max_accel: 1500
+max_z_velocity: 25
+max_z_accel: 30
+max_x_accel: 1200
+max_y_accel: 900
+scale_xy_accel: true

--- a/test/klippy/limited_cartesian.test
+++ b/test/klippy/limited_cartesian.test
@@ -1,0 +1,28 @@
+# Tests for limited_cartesian
+DICTIONARY atmega2560.dict
+CONFIG limited_cartesian.cfg
+
+; Start by homing the printer.
+G28
+G90
+G1 F6000
+
+M204 S1000
+
+; Z / X / Y moves
+G1 Z1
+G1 X1
+G1 Y1
+
+; test SET_KINEMATICS_LIMIT
+M204 S15000
+SET_KINEMATICS_LIMIT X_ACCEL=12000 Y_ACCEL=900 X_VELOCITY=300 Y_VELOCITY=200 SCALE=0
+SET_KINEMATICS_LIMIT
+
+; diagonal moves
+G1 X0 Y0
+G1 X1 Z2
+G1 X0 Y1 Z1
+
+; regular extrude move
+G1 X0 Y0 E.01

--- a/test/klippy/limited_corexy.cfg
+++ b/test/klippy/limited_corexy.cfg
@@ -1,0 +1,74 @@
+
+[stepper_x]
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PE5
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_y]
+step_pin: PF6
+dir_pin: PF7
+enable_pin: !PF2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PJ1
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_z]
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PD3
+position_endstop: 0.5
+position_max: 200
+
+[extruder]
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 33.500
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PB4
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PK5
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 250
+
+[heater_bed]
+heater_pin: PH5
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK6
+control: watermark
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: PH6
+
+[mcu]
+serial: /dev/ttyACM0
+
+[printer]
+kinematics: limited_corexy
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 25
+max_z_accel: 30
+max_x_accel: 1200
+max_y_accel: 900
+scale_xy_accel: true

--- a/test/klippy/limited_corexy.test
+++ b/test/klippy/limited_corexy.test
@@ -1,0 +1,28 @@
+# Tests for limited_cartesian
+DICTIONARY atmega2560.dict
+CONFIG limited_corexy.cfg
+
+; Start by homing the printer.
+G28
+G90
+G1 F6000
+
+M204 S1000
+
+; Z / X / Y moves
+G1 Z1
+G1 X1
+G1 Y1
+
+; test SET_KINEMATICS_LIMIT
+M204 S15000
+SET_KINEMATICS_LIMIT X_ACCEL=12000 Y_ACCEL=900 SCALE=0
+SET_KINEMATICS_LIMIT
+
+; diagonal moves
+G1 X0 Y0
+G1 X1 Z2
+G1 X0 Y1 Z1
+
+; regular extrude move
+G1 X0 Y0 E.01


### PR DESCRIPTION
I'll copy the relevant parts from the [Discourse thread](https://klipper.discourse.group/t/independant-acceleration-limits-for-x-and-y-axes/3831).

I've been using different accelerations and velocities limits for X and Y on my E3Pro for the past two years. Now that the code has been tested a bit by the community, I decided to share it here.

The syntax for the axis limits are similar to the ones for Z, `max_x_accel`, `max_x_velocity`, etc.

To get all the speedup benefits, main `max_accel` and `max_velocity` should be set to the hypotenuse: √(x²+y²). There is a new gcode command `SET_KINEMATICS_LIMIT` which will show these values and at the diagonal angle where they are reached.

If you set accelerations per feature type in the slicer, and have tuned your acceleration to get similar resonance amplitudes and level of smoothing on X and Y, you may want to enable `scale_xy_accel: true`. This will scale the X and Y accelerations by the ratio `M204 acceleration / config.max_accel`.
For example, if you have `max_accel: 10000` in your config and set in the slicer an acceleration of 5000 mm/s² (`M204 S5000`), effective `max_x_accel` and `max_y_accel` values will be halved compared to their original values set in the `[printer]` config. 
Otherwise, with `scale_xy_accel: false` (the default) they behave as machine limits, like `max_z_accel` and `max_z_velocity` always do. Gcode velocities under the limits are never scaled per axis and stay isotropic.

The corexy version has not been tried and tested enough, but it should work. There is no velocity per axis since the same steppers are used for both X and Y. Whereas cartesian printers may have motors with different characteristics on X and Y (inductance, and therefore torque pull-out velocities). However small CoreXY machines still benefit from lower Y acceleration since it has to move the gantry which is heavier than just the toolhead. One CoreXY, the X and Y accelerations don't immediately translate into a torque load of the A and B motors, so [the calculations](https://github.com/Piezoid/klipper/blob/work-peraxis/docs/PerAxisLimits.ipynb)  are a bit more complicated.

[klipper_estimator](https://github.com/Annex-Engineering/klipper_estimator) should support the limited_cartesian settings out of the box, with the exception of `scale_xy_accel`. I'm working on a patch.

Note that there are **print quality concerns** with anisotropic accelerations and velocities. This is the main reason that previous attempts to upstream something like this failed.
But I guess that's what this fork is about. :slightly_smiling_face: 

I open to renaming things and spelling fixes are welcome.