### PR TITLE
Upstream Sync GitHub Action

### DIFF
--- a/.github/workflows/upstream-sync.yaml
+++ b/.github/workflows/upstream-sync.yaml
@@ -1,0 +1,73 @@
+name: 'Upstream Sync'
+
+on:
+  schedule:
+    - cron:  '0 0 * * *'
+    # every day at midnight
+
+  workflow_dispatch:  # click the button on Github repo!
+
+jobs:
+  sync_latest_from_upstream:
+    runs-on: ubuntu-20.04
+    name: Sync latest commits from upstream repo
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.10.3
+        cache-dependency-path: scripts/requirements_dev.txt
+        cache: "pip"
+    - name: Pip install
+      run: pip install -r scripts/requirements_dev.txt
+    # REQUIRED step
+    # Step 1: run a standard checkout action, provided by github
+    - name: Checkout target repo
+      uses: actions/checkout@v2
+      with:
+        # optional: set the branch to checkout,
+        # sync action checks out your 'target_sync_branch' anyway
+        ref:  pure-klipper
+        # REQUIRED if your upstream repo is private (see wiki)
+        # persist-credentials: false
+
+    # REQUIRED step
+    # Step 2: run the sync action
+    - name: Sync upstream changes
+      id: sync
+      uses: aormsby/Fork-Sync-With-Upstream-action@v3.2
+      with:
+        target_sync_branch: pure-klipper
+        # REQUIRED 'target_repo_token' exactly like this!
+        target_repo_token: ${{ secrets.GITHUB_TOKEN }}
+        upstream_sync_branch: master
+        upstream_sync_repo: Klipper3d/klipper
+        # upstream_repo_access_token: ${{ secrets.UPSTREAM_REPO_SECRET }}
+
+        # Set test_mode true to run tests instead of the true action!!
+        test_mode: false
+          
+    - name: lint + format filtered branch
+      if: steps.sync.outputs.has_new_commits == 'true'
+      run: |
+        git config --global user.name 'GitHub Action'
+        git config --global user.email 'action@github.com'
+        git checkout -B pure-klipper-filtered
+        git checkout origin/master -- .flake8
+        git checkout origin/master -- pyproject.toml
+        black klippy
+        pip install autoflake
+        pip install autopep8
+        echo "running autoflake..."
+        autoflake --recursive --in-place klippy
+        echo "running autopep8..."
+        autopep8 --recursive --in-place klippy -a -a
+        rm .flake8
+        rm pyproject.toml
+        black klippy
+        git add .
+        git commit -m "autoformatting + linting"
+        git push origin pure-klipper-filtered -f
+


### PR DESCRIPTION
Filter branch without using git filter-branch I guess?

Process is as follows:

* Sync upstream klipper to `pure-klipper`
* Create and checkout new branch, `pure-klipper-filtered`
* Check out flake8 and black config from master branch
* Run black
* Run autoflake
* Run autopep8
* Run black again
* Remove black and flake8 config files
* Commit results to `pure-klipper-filtered`