### PR TITLE
docs: highlight Danger specific features, admonitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
-out
+/out/
+/site/
+/docs/_klipper3d/mkdocs-main.yml
 *.so
 *.pyc
-.config
-.config.old
-klippy/.version
+__pycache__
+/.config*
+/klippy/.version
 .history/
 .DS_Store

--- a/docs/API_Server.md
+++ b/docs/API_Server.md
@@ -7,10 +7,11 @@ control the Klipper host software.
 ## Enabling the API socket
 
 In order to use the API server, the klippy.py host software must be
-started with the `-a` parameter. For example:
-```
-~/klippy-env/bin/python ~/klipper/klippy/klippy.py ~/printer.cfg -a /tmp/klippy_uds -l /tmp/klippy.log
-```
+started with the `-a` parameter.
+!!! example
+    ```
+    ~/klippy-env/bin/python ~/klipper/klippy/klippy.py ~/printer.cfg -a /tmp/klippy_uds -l /tmp/klippy.log
+    ```
 
 This causes the host software to create a Unix Domain Socket. A client
 can then open a connection on that socket and send commands to
@@ -27,12 +28,12 @@ terminated by an ASCII 0x03 character:
 ```
 <json_object_1><0x03><json_object_2><0x03>...
 ```
-
-Klipper contains a `scripts/whconsole.py` tool that can perform the
-above message framing. For example:
-```
-~/klipper/scripts/whconsole.py /tmp/klippy_uds
-```
+!!! tip
+    Klipper contains a `scripts/whconsole.py` tool that can perform the
+    above message framing. For example:
+    ```
+    ~/klipper/scripts/whconsole.py /tmp/klippy_uds
+    ```
 
 This tool can read a series of JSON commands from stdin, send them to
 Klipper, and report the results. The tool expects each JSON command to
@@ -45,18 +46,20 @@ not have a newline requirement.)
 The command protocol used on the communication socket is inspired by
 [json-rpc](https://www.jsonrpc.org/).
 
-A request might look like:
 
-`{"id": 123, "method": "info", "params": {}}`
+!!! example
+    A request might look like:
 
-and a response might look like:
+    `{"id": 123, "method": "info", "params": {}}`
 
-`{"id": 123, "result": {"state_message": "Printer is ready",
-"klipper_path": "/home/pi/klipper", "config_file":
-"/home/pi/printer.cfg", "software_version": "v0.8.0-823-g883b1cb6",
-"hostname": "octopi", "cpu_info": "4 core ARMv7 Processor rev 4
-(v7l)", "state": "ready", "python_path":
-"/home/pi/klippy-env/bin/python", "log_file": "/tmp/klippy.log"}}`
+    and a response might look like:
+
+    `{"id": 123, "result": {"state_message": "Printer is ready",
+    "klipper_path": "/home/pi/klipper", "config_file":
+    "/home/pi/printer.cfg", "software_version": "v0.8.0-823-g883b1cb6",
+    "hostname": "octopi", "cpu_info": "4 core ARMv7 Processor rev 4
+    (v7l)", "state": "ready", "python_path":
+    "/home/pi/klippy-env/bin/python", "log_file": "/tmp/klippy.log"}}`
 
 Each request must be a JSON dictionary. (This document uses the Python
 term "dictionary" to describe a "JSON object" - a mapping of key/value
@@ -79,13 +82,17 @@ containing "id" and "result". The "result" is always a dictionary -
 its contents are specific to the "endpoint" handling the request.
 
 If the processing of a request results in an error, then the response
-message will contain an "error" field instead of a "result" field. For
-example, the request:
-`{"id": 123, "method": "gcode/script", "params": {"script": "G1
-X200"}}`
-might result in an error response such as:
-`{"id": 123, "error": {"message": "Must home axis
-first: 200.000 0.000 0.000 [0.000]", "error": "WebRequestError"}}`
+message will contain an "error" field instead of a "result" field.
+!!! example
+    The request:
+
+    `{"id": 123, "method": "gcode/script", "params": {"script": "G1
+    X200"}}`
+
+    might result in an error response such as:
+
+    `{"id": 123, "error": {"message": "Must home axis
+    first: 200.000 0.000 0.000 [0.000]", "error": "WebRequestError"}}`
 
 Klipper will always start processing requests in the order that they
 are received. However, some request may not complete immediately,
@@ -98,18 +105,17 @@ pause the processing of future JSON requests.
 Some Klipper "endpoint" requests allow one to "subscribe" to future
 asynchronous update messages.
 
-For example:
+!!! example
+    `{"id": 123, "method": "gcode/subscribe_output", "params":
+    {"response_template":{"key": 345}}}`
 
-`{"id": 123, "method": "gcode/subscribe_output", "params":
-{"response_template":{"key": 345}}}`
+    may initially respond with:
 
-may initially respond with:
+    `{"id": 123, "result": {}}`
 
-`{"id": 123, "result": {}}`
+    and cause Klipper to send future messages similar to:
 
-and cause Klipper to send future messages similar to:
-
-`{"params": {"response": "ok B:22.8 /0.0 T0:22.4 /0.0"}, "key": 345}`
+    `{"params": {"response": "ok B:22.8 /0.0 T0:22.4 /0.0"}, "key": 345}`
 
 A subscription request accepts a "response_template" dictionary in the
 "params" field of the request. That "response_template" dictionary is
@@ -131,9 +137,10 @@ dictionary (eg, `{"method"="gcode/restart"}`).
 
 The "info" endpoint is used to obtain system and version information
 from Klipper. It is also used to provide the client's version
-information to Klipper. For example:
-`{"id": 123, "method": "info", "params": { "client_info": { "version":
-"v1"}}}`
+information to Klipper.
+!!! example
+    `{"id": 123, "method": "info", "params": { "client_info": { "version":
+    "v1"}}}`
 
 If present, the "client_info" parameter must be a dictionary, but that
 dictionary may have arbitrary contents. Clients are encouraged to
@@ -144,29 +151,32 @@ connecting to the Klipper API server.
 
 The "emergency_stop" endpoint is used to instruct Klipper to
 transition to a "shutdown" state. It behaves similarly to the G-Code
-`M112` command. For example:
-`{"id": 123, "method": "emergency_stop"}`
+`M112` command.
+!!! example
+    `{"id": 123, "method": "emergency_stop"}`
 
 ### register_remote_method
 
 This endpoint allows clients to register methods that can be called
 from klipper.  It will return an empty object upon success.
+!!! example
+    `{"id": 123, "method": "register_remote_method",
+    "params": {"response_template": {"action": "run_paneldue_beep"},
+    "remote_method": "paneldue_beep"}}`
 
-For example:
-`{"id": 123, "method": "register_remote_method",
-"params": {"response_template": {"action": "run_paneldue_beep"},
-"remote_method": "paneldue_beep"}}`
-will return:
-`{"id": 123, "result": {}}`
+    will return:
+
+    `{"id": 123, "result": {}}`
 
 The remote method `paneldue_beep` may now be called from Klipper. Note
 that if the method takes parameters they should be provided as keyword
 arguments. Below is an example of how it may called from a gcode_macro:
-```
-[gcode_macro PANELDUE_BEEP]
-gcode:
-  {action_call_remote_method("paneldue_beep", frequency=300, duration=1.0)}
-```
+!!! example
+    ```
+    [gcode_macro PANELDUE_BEEP]
+    gcode:
+      {action_call_remote_method("paneldue_beep", frequency=300, duration=1.0)}
+    ```
 
 When the PANELDUE_BEEP gcode macro is executed, Klipper would send something
 like the following over the socket:
@@ -176,23 +186,28 @@ like the following over the socket:
 ### objects/list
 
 This endpoint queries the list of available printer "objects" that one
-may query (via the "objects/query" endpoint). For example:
-`{"id": 123, "method": "objects/list"}`
-might return:
-`{"id": 123, "result": {"objects":
-["webhooks", "configfile", "heaters", "gcode_move", "query_endstops",
-"idle_timeout", "toolhead", "extruder"]}}`
+may query (via the "objects/query" endpoint).
+!!! example
+    `{"id": 123, "method": "objects/list"}`
+
+    might return:
+
+    `{"id": 123, "result": {"objects":
+    ["webhooks", "configfile", "heaters", "gcode_move", "query_endstops",
+    "idle_timeout", "toolhead", "extruder"]}}`
 
 ### objects/query
 
 This endpoint allows one to query information from printer objects.
-For example:
-`{"id": 123, "method": "objects/query", "params": {"objects":
-{"toolhead": ["position"], "webhooks": null}}}`
-might return:
-`{"id": 123, "result": {"status": {"webhooks": {"state": "ready",
-"state_message": "Printer is ready"}, "toolhead": {"position":
-[0.0, 0.0, 0.0, 0.0]}}, "eventtime": 3051555.377933684}}`
+!!! example
+    `{"id": 123, "method": "objects/query", "params": {"objects":
+    {"toolhead": ["position"], "webhooks": null}}}`
+
+    might return:
+
+    `{"id": 123, "result": {"status": {"webhooks": {"state": "ready",
+    "state_message": "Printer is ready"}, "toolhead": {"position":
+    [0.0, 0.0, 0.0, 0.0]}}, "eventtime": 3051555.377933684}}`
 
 The "objects" parameter in the request must be a dictionary containing
 the printer objects that are to be queried - the key contains the
@@ -212,32 +227,41 @@ Available fields are documented in the
 
 This endpoint allows one to query and then subscribe to information
 from printer objects. The endpoint request and response is identical
-to the "objects/query" endpoint. For example:
-`{"id": 123, "method": "objects/subscribe", "params":
-{"objects":{"toolhead": ["position"], "webhooks": ["state"]},
-"response_template":{}}}`
-might return:
-`{"id": 123, "result": {"status": {"webhooks": {"state": "ready"},
-"toolhead": {"position": [0.0, 0.0, 0.0, 0.0]}},
-"eventtime": 3052153.382083195}}`
-and result in subsequent asynchronous messages such as:
-`{"params": {"status": {"webhooks": {"state": "shutdown"}},
-"eventtime": 3052165.418815847}}`
+to the "objects/query" endpoint.
+!!! example
+    `{"id": 123, "method": "objects/subscribe", "params":
+    {"objects":{"toolhead": ["position"], "webhooks": ["state"]},
+    "response_template":{}}}`
+
+    might return:
+
+    `{"id": 123, "result": {"status": {"webhooks": {"state": "ready"},
+    "toolhead": {"position": [0.0, 0.0, 0.0, 0.0]}},
+    "eventtime": 3052153.382083195}}`
+
+    and result in subsequent asynchronous messages such as:
+
+    `{"params": {"status": {"webhooks": {"state": "shutdown"}},
+    "eventtime": 3052165.418815847}}`
 
 ### gcode/help
 
 This endpoint allows one to query available G-Code commands that have
-a help string defined. For example:
-`{"id": 123, "method": "gcode/help"}`
-might return:
-`{"id": 123, "result": {"RESTORE_GCODE_STATE": "Restore a previously
-saved G-Code state", "PID_CALIBRATE": "Run PID calibration test",
-"QUERY_ADC": "Report the last value of an analog pin", ...}}`
+a help string defined.
+!!! example
+    `{"id": 123, "method": "gcode/help"}`
+
+    might return:
+
+    `{"id": 123, "result": {"RESTORE_GCODE_STATE": "Restore a previously
+    saved G-Code state", "PID_CALIBRATE": "Run PID calibration test",
+    "QUERY_ADC": "Report the last value of an analog pin", ...}}`
 
 ### gcode/script
 
-This endpoint allows one to run a series of G-Code commands. For example:
-`{"id": 123, "method": "gcode/script", "params": {"script": "G90"}}`
+This endpoint allows one to run a series of G-Code commands.
+!!! example
+    `{"id": 123, "method": "gcode/script", "params": {"script": "G90"}}`
 
 If the provided G-Code script raises an error, then an error response
 is generated. However, if the G-Code command produces terminal output,
@@ -253,8 +277,9 @@ fully completes.
 ### gcode/restart
 
 This endpoint allows one to request a restart - it is similar to
-running the G-Code "RESTART" command. For example:
-`{"id": 123, "method": "gcode/restart"}`
+running the G-Code "RESTART" command.
+!!! example
+    `{"id": 123, "method": "gcode/restart"}`
 
 As with the "gcode/script" endpoint, this endpoint only completes
 after any pending G-Code commands complete.
@@ -262,8 +287,9 @@ after any pending G-Code commands complete.
 ### gcode/firmware_restart
 
 This is similar to the "gcode/restart" endpoint - it implements the
-G-Code "FIRMWARE_RESTART" command. For example:
-`{"id": 123, "method": "gcode/firmware_restart"}`
+G-Code "FIRMWARE_RESTART" command.
+!!! example
+    `{"id": 123, "method": "gcode/firmware_restart"}`
 
 As with the "gcode/script" endpoint, this endpoint only completes
 after any pending G-Code commands complete.
@@ -271,11 +297,14 @@ after any pending G-Code commands complete.
 ### gcode/subscribe_output
 
 This endpoint is used to subscribe to G-Code terminal messages that
-are generated by Klipper. For example:
-`{"id": 123, "method": "gcode/subscribe_output", "params":
-{"response_template":{}}}`
-might later produce asynchronous messages such as:
-`{"params": {"response": "// Klipper state: Shutdown"}}`
+are generated by Klipper.
+!!! example
+    `{"id": 123, "method": "gcode/subscribe_output", "params":
+    {"response_template":{}}}`
+
+    might later produce asynchronous messages such as:
+
+    `{"params": {"response": "// Klipper state: Shutdown"}}`
 
 This endpoint is intended to support human interaction via a "terminal
 window" interface. Parsing content from the G-Code terminal output is
@@ -289,17 +318,23 @@ queue_step command stream for a stepper. Obtaining these low-level
 motion updates may be useful for diagnostic and debugging
 purposes. Using this endpoint may increase Klipper's system load.
 
-A request may look like:
-`{"id": 123, "method":"motion_report/dump_stepper",
-"params": {"name": "stepper_x", "response_template": {}}}`
-and might return:
-`{"id": 123, "result": {"header": ["interval", "count", "add"]}}`
-and might later produce asynchronous messages such as:
-`{"params": {"first_clock": 179601081, "first_time": 8.98,
-"first_position": 0, "last_clock": 219686097, "last_time": 10.984,
-"data": [[179601081, 1, 0], [29573, 2, -8685], [16230, 4, -1525],
-[10559, 6, -160], [10000, 976, 0], [10000, 1000, 0], [10000, 1000, 0],
-[10000, 1000, 0], [9855, 5, 187], [11632, 4, 1534], [20756, 2, 9442]]}}`
+!!! example
+    A request may look like:
+
+    `{"id": 123, "method":"motion_report/dump_stepper",
+    "params": {"name": "stepper_x", "response_template": {}}}`
+
+    and might return:
+
+    `{"id": 123, "result": {"header": ["interval", "count", "add"]}}`
+
+    and might later produce asynchronous messages such as:
+
+    `{"params": {"first_clock": 179601081, "first_time": 8.98,
+    "first_position": 0, "last_clock": 219686097, "last_time": 10.984,
+    "data": [[179601081, 1, 0], [29573, 2, -8685], [16230, 4, -1525],
+    [10559, 6, -160], [10000, 976, 0], [10000, 1000, 0], [10000, 1000, 0],
+    [10000, 1000, 0], [9855, 5, 187], [11632, 4, 1534], [20756, 2, 9442]]}}`
 
 The "header" field in the initial query response is used to describe
 the fields found in later "data" responses.
@@ -311,16 +346,22 @@ motion queue". Obtaining these low-level motion updates may be useful
 for diagnostic and debugging purposes. Using this endpoint may
 increase Klipper's system load.
 
-A request may look like:
-`{"id": 123, "method": "motion_report/dump_trapq", "params":
-{"name": "toolhead", "response_template":{}}}`
-and might return:
-`{"id": 1, "result": {"header": ["time", "duration",
-"start_velocity", "acceleration", "start_position", "direction"]}}`
-and might later produce asynchronous messages such as:
-`{"params": {"data": [[4.05, 1.0, 0.0, 0.0, [300.0, 0.0, 0.0],
-[0.0, 0.0, 0.0]], [5.054, 0.001, 0.0, 3000.0, [300.0, 0.0, 0.0],
-[-1.0, 0.0, 0.0]]]}}`
+!!! example
+    A request may look like:
+
+    `{"id": 123, "method": "motion_report/dump_trapq", "params":
+    {"name": "toolhead", "response_template":{}}}`
+
+    and might return:
+
+    `{"id": 1, "result": {"header": ["time", "duration",
+    "start_velocity", "acceleration", "start_position", "direction"]}}`
+
+    and might later produce asynchronous messages such as:
+
+    `{"params": {"data": [[4.05, 1.0, 0.0, 0.0, [300.0, 0.0, 0.0],
+    [0.0, 0.0, 0.0]], [5.054, 0.001, 0.0, 3000.0, [300.0, 0.0, 0.0],
+    [-1.0, 0.0, 0.0]]]}}`
 
 The "header" field in the initial query response is used to describe
 the fields found in later "data" responses.
@@ -332,15 +373,19 @@ Obtaining these low-level motion updates may be useful for diagnostic
 and debugging purposes. Using this endpoint may increase Klipper's
 system load.
 
-A request may look like:
-`{"id": 123, "method":"adxl345/dump_adxl345",
-"params": {"sensor": "adxl345", "response_template": {}}}`
-and might return:
-`{"id": 123,"result":{"header":["time","x_acceleration","y_acceleration",
-"z_acceleration"]}}`
-and might later produce asynchronous messages such as:
-`{"params":{"overflows":0,"data":[[3292.432935,-535.44309,-1529.8374,9561.4],
-[3292.433256,-382.45935,-1606.32927,9561.48375]]}}`
+!!! example
+    `{"id": 123, "method":"adxl345/dump_adxl345",
+    "params": {"sensor": "adxl345", "response_template": {}}}`
+
+    and might return:
+
+    `{"id": 123,"result":{"header":["time","x_acceleration","y_acceleration",
+    "z_acceleration"]}}`
+
+    and might later produce asynchronous messages such as:
+
+    `{"params":{"overflows":0,"data":[[3292.432935,-535.44309,-1529.8374,9561.4],
+    [3292.433256,-382.45935,-1606.32927,9561.48375]]}}`
 
 The "header" field in the initial query response is used to describe
 the fields found in later "data" responses.
@@ -352,14 +397,18 @@ This endpoint is used to subscribe to
 low-level motion updates may be useful for diagnostic and debugging
 purposes. Using this endpoint may increase Klipper's system load.
 
-A request may look like:
-`{"id": 123, "method":"angle/dump_angle",
-"params": {"sensor": "my_angle_sensor", "response_template": {}}}`
-and might return:
-`{"id": 123,"result":{"header":["time","angle"]}}`
-and might later produce asynchronous messages such as:
-`{"params":{"position_offset":3.151562,"errors":0,
-"data":[[1290.951905,-5063],[1290.952321,-5065]]}}`
+!!! example
+    `{"id": 123, "method":"angle/dump_angle",
+    "params": {"sensor": "my_angle_sensor", "response_template": {}}}`
+
+    and might return:
+
+    `{"id": 123,"result":{"header":["time","angle"]}}`
+
+    and might later produce asynchronous messages such as:
+
+    `{"params":{"position_offset":3.151562,"errors":0,
+    "data":[[1290.951905,-5063],[1290.952321,-5065]]}}`
 
 The "header" field in the initial query response is used to describe
 the fields found in later "data" responses.
@@ -367,26 +416,26 @@ the fields found in later "data" responses.
 ### pause_resume/cancel
 
 This endpoint is similar to running the "PRINT_CANCEL" G-Code command.
-For example:
-`{"id": 123, "method": "pause_resume/cancel"}`
+!!! example
+    `{"id": 123, "method": "pause_resume/cancel"}`
 
 As with the "gcode/script" endpoint, this endpoint only completes
 after any pending G-Code commands complete.
 
 ### pause_resume/pause
 
-This endpoint is similar to running the "PAUSE" G-Code command. For
-example:
-`{"id": 123, "method": "pause_resume/pause"}`
+This endpoint is similar to running the "PAUSE" G-Code command.
+!!! example
+    `{"id": 123, "method": "pause_resume/pause"}`
 
 As with the "gcode/script" endpoint, this endpoint only completes
 after any pending G-Code commands complete.
 
 ### pause_resume/resume
 
-This endpoint is similar to running the "RESUME" G-Code command. For
-example:
-`{"id": 123, "method": "pause_resume/resume"}`
+This endpoint is similar to running the "RESUME" G-Code command.
+!!! example
+    `{"id": 123, "method": "pause_resume/resume"}`
 
 As with the "gcode/script" endpoint, this endpoint only completes
 after any pending G-Code commands complete.
@@ -394,10 +443,12 @@ after any pending G-Code commands complete.
 ### query_endstops/status
 
 This endpoint will query the active endpoints and return their status.
-For example:
-`{"id": 123, "method": "query_endstops/status"}`
-might return:
-`{"id": 123, "result": {"y": "open", "x": "open", "z": "TRIGGERED"}}`
+!!! example
+    `{"id": 123, "method": "query_endstops/status"}`
+
+    might return:
+
+    `{"id": 123, "result": {"y": "open", "x": "open", "z": "TRIGGERED"}}`
 
 As with the "gcode/script" endpoint, this endpoint only completes
 after any pending G-Code commands complete.

--- a/docs/BLTouch.md
+++ b/docs/BLTouch.md
@@ -12,31 +12,33 @@ the BL-Touch documentation or your MCU documentation. Using the
 original wiring, the yellow wire from the triple is the `control_pin`
 and the white wire from the pair is the `sensor_pin`. You need to
 configure these pins according to your wiring. Most BL-Touch devices
-require a pullup on the sensor pin (prefix the pin name with "^"). For
-example:
+require a pullup on the sensor pin (prefix the pin name with "^").
 
-```
-[bltouch]
-sensor_pin: ^P1.24
-control_pin: P1.26
-```
+!!! example
+    ```
+    [bltouch]
+    sensor_pin: ^P1.24
+    control_pin: P1.26
+    ```
 
 If the BL-Touch will be used to home the Z axis then set `endstop_pin:
 probe:z_virtual_endstop` and remove `position_endstop` in the `[stepper_z]` config section,
 then add a `[safe_z_home]` config section to raise the z axis, home the xy axes,
-move to the center of the bed, and home the z axis. For example:
+move to the center of the bed, and home the z axis.
 
-```
-[safe_z_home]
-home_xy_position: 100, 100 # Change coordinates to the center of your print bed
-speed: 50
-z_hop: 10                 # Move up 10mm
-z_hop_speed: 5
-```
+!!! example
+    ```
+    [safe_z_home]
+    home_xy_position: 100, 100 # Change coordinates to the center of your print bed
+    speed: 50
+    z_hop: 10                 # Move up 10mm
+    z_hop_speed: 5
+    ```
 
-It's important that the z_hop movement in safe_z_home is high enough
-that the probe doesn't hit anything even if the probe pin happens to
-be in its lowest state.
+!!! important
+    It's important that the z_hop movement in safe_z_home is high enough
+    that the probe doesn't hit anything even if the probe pin happens to be
+    in its lowest state.
 
 ## Initial tests
 
@@ -112,11 +114,12 @@ the `QUERY_PROBE` command and some "clone" devices may require
 configuration of `pin_up_reports_not_triggered` or
 `pin_up_touch_mode_reports_triggered`.
 
-Important! Do not configure `pin_up_reports_not_triggered` or
-`pin_up_touch_mode_reports_triggered` to False without first following
-these directions. Do not configure either of these to False on a
-genuine BL-Touch. Incorrectly setting these to False can increase
-probing time and can increase the risk of damaging the printer.
+!!! important
+    Do not configure `pin_up_reports_not_triggered` or
+    `pin_up_touch_mode_reports_triggered` to False without first following
+    these directions. Do not configure either of these to False on a
+    genuine BL-Touch. Incorrectly setting these to False can increase
+    probing time and can increase the risk of damaging the printer.
 
 Some "clone" devices do not support `touch_mode` and as a result the
 `QUERY_PROBE` command does not work. Despite this, it may still be
@@ -172,12 +175,13 @@ successfully contacts the bed. Klipper should clear this error
 automatically and it is generally harmless. However, one may set
 `probe_with_touch_mode` in the config file to avoid this issue.
 
-Important! Some "clone" devices and the BL-Touch v2.0 (and earlier)
-may have reduced accuracy when `probe_with_touch_mode` is set to True.
-Setting this to True also increases the time it takes to deploy the
-probe. If configuring this value on a "clone" or older BL-Touch
-device, be sure to test the probe accuracy before and after setting
-this value (use the `PROBE_ACCURACY` command to test).
+!!! important
+    Some "clone" devices and the BL-Touch v2.0 (and earlier) may have
+    reduced accuracy when `probe_with_touch_mode` is set to True. Setting
+    this to True also increases the time it takes to deploy the probe. If
+    configuring this value on a "clone" or older BL-Touch device, be sure
+    to test the probe accuracy before and after setting this value (use the
+    `PROBE_ACCURACY` command to test).
 
 ## Multi-probing without stowing
 
@@ -189,19 +193,21 @@ leaving the probe deployed between consecutive probes, which can
 reduce the total time of probing. This mode is enabled by configuring
 `stow_on_each_sample` to False in the config file.
 
-Important! Setting `stow_on_each_sample` to False can lead to Klipper
-making horizontal toolhead movements while the probe is deployed. Be
-sure to verify all probing operations have sufficient Z clearance
-prior to setting this value to False. If there is insufficient
-clearance then a horizontal move may cause the pin to catch on an
-obstruction and result in damage to the printer.
+!!! important
+    Setting `stow_on_each_sample` to False can lead to Klipper making
+    horizontal toolhead movements while the probe is deployed. Be sure to
+    verify all probing operations have sufficient Z clearance prior to
+    setting this value to False. If there is insufficient clearance then a
+    horizontal move may cause the pin to catch on an obstruction and result
+    in damage to the printer.
 
-Important! It is recommended to use `probe_with_touch_mode` configured
-to True when using `stow_on_each_sample` configured to False. Some
-"clone" devices may not detect a subsequent bed contact if
-`probe_with_touch_mode` is not set. On all devices, using the
-combination of these two settings simplifies the device signaling,
-which can improve overall stability.
+!!! important
+    It is recommended to use `probe_with_touch_mode` configured to True
+    when using `stow_on_each_sample` configured to False. Some "clone"
+    devices may not detect a subsequent bed contact if
+    `probe_with_touch_mode` is not set. On all devices, using the
+    combination of these two settings simplifies the device signaling,
+    which can improve overall stability.
 
 Note, however, that some "clone" devices and the BL-Touch v2.0 (and
 earlier) may have reduced accuracy when `probe_with_touch_mode` is set

--- a/docs/Bed_Level.md
+++ b/docs/Bed_Level.md
@@ -70,7 +70,8 @@ The first step of the paper test is to inspect the printer's nozzle
 and bed. Make sure there is no plastic (or other debris) on the nozzle
 or bed.
 
-**Inspect the nozzle and bed to ensure no plastic is present!**
+!!! important
+    Inspect the nozzle and bed to ensure no plastic is present!
 
 If one always prints on a particular tape or printing surface then one
 may perform the paper test with that tape/surface in place. However,
@@ -134,10 +135,11 @@ down on the bed when moving the paper back and forth.)
 ![paper-test](img/paper-test.jpg)
 
 Use the TESTZ command to request the nozzle to move closer to the
-paper. For example:
-```
-TESTZ Z=-.1
-```
+paper.
+!!! example
+    ```
+    TESTZ Z=-.1
+    ```
 
 The TESTZ command will move the nozzle a relative distance from the
 nozzle's current position. (So, `Z=-.1` requests the nozzle to move
@@ -150,11 +152,12 @@ the paper.
 If too much friction is found then one can use a positive Z value to
 move the nozzle up. It is also possible to use `TESTZ Z=+` or `TESTZ
 Z=-` to "bisect" the last position - that is to move to a position
-half way between two positions. For example, if one received the
-following prompt from a TESTZ command:
-```
-Recv: // Z position: 0.130 --> 0.230 <-- 0.280
-```
+half way between two positions.
+!!! example
+    If one received the following prompt from a TESTZ command:
+    ```
+    Recv: // Z position: 0.130 --> 0.230 <-- 0.280
+    ```
 Then a `TESTZ Z=-` would move the nozzle to a Z position of 0.180
 (half way between 0.130 and 0.230). One can use this feature to help
 rapidly narrow down to a consistent friction. It is also possible to

--- a/docs/Benchmarks.md
+++ b/docs/Benchmarks.md
@@ -74,8 +74,9 @@ cut-and-paste into the console.py window.
 To produce the benchmarks found in the [Features](Features.md) document, the total
 number of steps per second is calculated by multiplying the number of
 active steppers with the nominal mcu frequency and dividing by the
-final ticks parameter. The results are rounded to the nearest K. For
-example, with three active steppers:
+final ticks parameter. The results are rounded to the nearest K.
+
+!!! example "Example with three active steppers:
 ```
 ECHO Test result is: {"%.0fK" % (3. * freq / ticks / 1000.)}
 ```
@@ -392,12 +393,12 @@ When the test completes, determine the difference between the clocks
 reported in the two "uptime" response messages. The total number of
 commands per second is then `100000 * mcu_frequency / clock_diff`.
 
-Note that this test may saturate the USB/CPU capacity of a Raspberry
-Pi. If running on a Raspberry Pi, Beaglebone, or similar host computer
-then increase the delay (eg, `DELAY {clock + 20*freq} get_uptime`).
-Where applicable, the benchmarks below are with console.py running on
-a desktop class machine with the device connected via a high-speed
-hub.
+!!! note
+    This test may saturate the USB/CPU capacity of a Raspberry Pi. If
+    running on a Raspberry Pi, Beaglebone, or similar host computer then
+    increase the delay (eg, `DELAY {clock + 20*freq} get_uptime`). Where
+    applicable, the benchmarks below are with console.py running on a
+    desktop class machine with the device connected via a high-speed hub.
 
 | MCU                 | Rate | Build    | Build compiler      |
 | ------------------- | ---- | -------- | ------------------- |
@@ -422,7 +423,8 @@ It is possible to run timing tests on the host software using the
 "batch mode" processing mechanism (described in
 [Debugging.md](Debugging.md)). This is typically done by choosing a
 large and complex G-Code file and timing how long it takes for the
-host software to process it. For example:
-```
-time ~/klippy-env/bin/python ./klippy/klippy.py config/example-cartesian.cfg -i something_complex.gcode -o /dev/null -d out/klipper.dict
-```
+host software to process it.
+!!! example
+    ```
+    time ~/klippy-env/bin/python ./klippy/klippy.py config/example-cartesian.cfg -i something_complex.gcode -o /dev/null -d out/klipper.dict
+    ```

--- a/docs/Bootloaders.md
+++ b/docs/Bootloaders.md
@@ -102,12 +102,13 @@ To flash an application use something like:
 avrdude -carduino -patmega1284p -P/dev/ttyACM0 -b115200 -D -Uflash:w:out/klipper.elf.hex:i
 ```
 
-Note that a number of "Melzi" style boards come preloaded with a
-bootloader that uses a baud rate of 57600. In this case, to flash an
-application use something like this instead:
-```
-avrdude -carduino -patmega1284p -P/dev/ttyACM0 -b57600 -D -Uflash:w:out/klipper.elf.hex:i
-```
+!!! note "Note: Melzi boards"
+    A number of "Melzi" style boards come preloaded with a bootloader that
+    uses a baud rate of 57600. In this case, to flash an application use
+    something like this instead:
+    ```
+    avrdude -carduino -patmega1284p -P/dev/ttyACM0 -b57600 -D -Uflash:w:out/klipper.elf.hex:i
+    ```
 
 ### At90usb1286
 
@@ -263,11 +264,12 @@ to flash the device using something like:
 stm32flash -w out/klipper.bin -v -g 0 /dev/ttyAMA0
 ```
 
-Note that if one is using a Raspberry Pi for the 3.3V serial, the
-stm32flash protocol uses a serial parity mode which the Raspberry Pi's
-"mini UART" does not support. See
-[https://www.raspberrypi.com/documentation/computers/configuration.html#configuring-uarts](https://www.raspberrypi.com/documentation/computers/configuration.html#configuring-uarts)
-for details on enabling the full uart on the Raspberry Pi GPIO pins.
+!!! note "Note: Raspberry Pi's mini UART"
+    If one is using a Raspberry Pi for the 3.3V serial, the stm32flash
+    protocol uses a serial parity mode which the Raspberry Pi's "mini UART"
+    does not support. See
+    [https://www.raspberrypi.com/documentation/computers/configuration.html#configuring-uarts](https://www.raspberrypi.com/documentation/computers/configuration.html#configuring-uarts)
+    for details on enabling the full uart on the Raspberry Pi GPIO pins.
 
 After flashing, set both "boot 0" and "boot 1" back to low so that
 future resets boot from flash.
@@ -329,30 +331,31 @@ finally, you can flash with commands similar to:
 stm32f1x mass_erase 0
 program hid_btt_skr_mini_e3.bin verify 0x08000000
 ```
-NOTES:
-- The example above erases the chip then programs the bootloader.  Regardless
-  of the method chosen to flash it is recommended to erase the chip prior to
-  flashing.
-- Prior flashing the SKR Mini E3 with this bootloader you should be aware
-  that you will no longer be able to update firmware via the sdcard.
-- You may need to hold down the reset button on the board while launching
-  OpenOCD.  It should display something like:
-  ```
-  Open On-Chip Debugger 0.10.0+dev-01204-gc60252ac-dirty (2020-04-27-16:00)
-  Licensed under GNU GPL v2
-  For bug reports, read
-          http://openocd.org/doc/doxygen/bugs.html
-  DEPRECATED! use 'adapter speed' not 'adapter_khz'
-  Info : BCM2835 GPIO JTAG/SWD bitbang driver
-  Info : JTAG and SWD modes enabled
-  Info : clock speed 40 kHz
-  Info : SWD DPIDR 0x1ba01477
-  Info : stm32f1x.cpu: hardware has 6 breakpoints, 4 watchpoints
-  Info : stm32f1x.cpu: external reset detected
-  Info : starting gdb server for stm32f1x.cpu on 3333
-  Info : Listening on port 3333 for gdb connections
-  ```
-  After which you can release the reset button.
+!!! note
+    - The example above erases the chip then programs the bootloader.
+      Regardless of the method chosen to flash it is recommended to erase
+      the chip prior to flashing.
+    - Prior flashing the SKR Mini E3 with this bootloader you should be
+      aware that you will no longer be able to update firmware via the
+      sdcard.
+    - You may need to hold down the reset button on the board while
+      launching OpenOCD.  It should display something like:
+      ```
+      Open On-Chip Debugger 0.10.0+dev-01204-gc60252ac-dirty (2020-04-27-16:00)
+      Licensed under GNU GPL v2
+      For bug reports, read
+              http://openocd.org/doc/doxygen/bugs.html
+      DEPRECATED! use 'adapter speed' not 'adapter_khz'
+      Info : BCM2835 GPIO JTAG/SWD bitbang driver
+      Info : JTAG and SWD modes enabled
+      Info : clock speed 40 kHz
+      Info : SWD DPIDR 0x1ba01477
+      Info : stm32f1x.cpu: hardware has 6 breakpoints, 4 watchpoints
+      Info : stm32f1x.cpu: external reset detected
+      Info : starting gdb server for stm32f1x.cpu on 3333
+      Info : Listening on port 3333 for gdb connections
+      ```
+      After which you can release the reset button.
 
 
 This bootloader requires 2KiB of flash space (the application
@@ -461,12 +464,12 @@ board, a [build for the SKR Pro 1.1 is available here](
 Unless your board is DFU capable the most accessable flashing method
 is likely via 3.3v serial, which follows the same procedure as
 [flashing the STM32F103 using stm32flash](#stm32f103-micro-controllers-blue-pill-devices).
-For example:
-```
-wget https://github.com/Arksine/STM32_HID_Bootloader/releases/download/v0.5-beta/hid_bootloader_SKR_PRO.bin
+!!! example
+    ```
+    wget https://github.com/Arksine/STM32_HID_Bootloader/releases/download/v0.5-beta/hid_bootloader_SKR_PRO.bin
 
-stm32flash -w hid_bootloader_SKR_PRO.bin -v -g 0 /dev/ttyAMA0
-```
+    stm32flash -w hid_bootloader_SKR_PRO.bin -v -g 0 /dev/ttyAMA0
+    ```
 
 This bootloader requires 16Kib of flash space on the STM32F4 (the application
 must be compiled with a start address of 16KiB).

--- a/docs/CANBUS.md
+++ b/docs/CANBUS.md
@@ -39,8 +39,9 @@ iface can0 can static
     up ifconfig $IFACE txqueuelen 128
 ```
 
-Note that the "Raspberry Pi CAN hat" also requires
-[changes to config.txt](https://www.waveshare.com/wiki/RS485_CAN_HAT).
+!!! note "Note: Raspberry Pi CAN hat"
+  The "Raspberry Pi CAN hat" also requires [changes to
+  config.txt](https://www.waveshare.com/wiki/RS485_CAN_HAT).
 
 ## Terminating Resistors
 
@@ -86,11 +87,12 @@ will no longer appear in the list.
 ## Configuring Klipper
 
 Update the Klipper [mcu configuration](Config_Reference.md#mcu) to use
-the CAN bus to communicate with the device - for example:
-```
-[mcu my_can_mcu]
-canbus_uuid: 11aa22bb33cc
-```
+the CAN bus to communicate with the device.
+!!! example
+    ```
+    [mcu my_can_mcu]
+    canbus_uuid: 11aa22bb33cc
+    ```
 
 ## USB to CAN bus bridge mode
 

--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -15,35 +15,37 @@ MACRO25_TEST3 is not).
 
 Indentation is important when defining a macro in the config file. To
 specify a multi-line G-Code sequence it is important for each line to
-have proper indentation. For example:
+have proper indentation.
 
-```
-[gcode_macro blink_led]
-gcode:
-  SET_PIN PIN=my_led VALUE=1
-  G4 P2000
-  SET_PIN PIN=my_led VALUE=0
-```
+!!! example
+    ```
+    [gcode_macro blink_led]
+    gcode:
+      SET_PIN PIN=my_led VALUE=1
+      G4 P2000
+      SET_PIN PIN=my_led VALUE=0
+    ```
 
-Note how the `gcode:` config option always starts at the beginning of
-the line and subsequent lines in the G-Code macro never start at the
-beginning.
+!!! note
+    Note how the `gcode:` config option always starts at the beginning of
+    the line and subsequent lines in the G-Code macro never start at the
+    beginning.
 
 ## Add a description to your macro
 
 To help identify the functionality a short description can be added.
 Add `description:` with a short text to describe the functionality.
 Default is "G-Code macro" if not specified.
-For example:
 
-```
-[gcode_macro blink_led]
-description: Blink my_led one time
-gcode:
-  SET_PIN PIN=my_led VALUE=1
-  G4 P2000
-  SET_PIN PIN=my_led VALUE=0
-```
+!!! example
+    ```
+    [gcode_macro blink_led]
+    description: Blink my_led one time
+    gcode:
+      SET_PIN PIN=my_led VALUE=1
+      G4 P2000
+      SET_PIN PIN=my_led VALUE=0
+    ```
 
 The terminal will display the description when you use the `HELP` command or the autocomplete function.
 
@@ -60,16 +62,17 @@ issuing a `G1` command. (Otherwise, there is a risk the `G1` command
 will make an undesirable request.)
 
 A common way to accomplish that is to wrap the `G1` moves in
-`SAVE_GCODE_STATE`, `G91`, and `RESTORE_GCODE_STATE`. For example:
+`SAVE_GCODE_STATE`, `G91`, and `RESTORE_GCODE_STATE`.
 
-```
-[gcode_macro MOVE_UP]
-gcode:
-  SAVE_GCODE_STATE NAME=my_move_up_state
-  G91
-  G1 Z10 F300
-  RESTORE_GCODE_STATE NAME=my_move_up_state
-```
+!!! example
+    ```
+    [gcode_macro MOVE_UP]
+    gcode:
+      SAVE_GCODE_STATE NAME=my_move_up_state
+      G91
+      G1 Z10 F300
+      RESTORE_GCODE_STATE NAME=my_move_up_state
+    ```
 
 The `G91` command places the G-Code parsing state into "relative move
 mode" and the `RESTORE_GCODE_STATE` command restores the state to what
@@ -85,48 +88,54 @@ wrapped in `{% %}`. See the
 [Jinja2 documentation](http://jinja.pocoo.org/docs/2.10/templates/)
 for further information on the syntax.
 
-An example of a complex macro:
-```
-[gcode_macro clean_nozzle]
-gcode:
-  {% set wipe_count = 8 %}
-  SAVE_GCODE_STATE NAME=clean_nozzle_state
-  G90
-  G0 Z15 F300
-  {% for wipe in range(wipe_count) %}
-    {% for coordinate in [(275, 4),(235, 4)] %}
-      G0 X{coordinate[0]} Y{coordinate[1] + 0.25 * wipe} Z9.7 F12000
-    {% endfor %}
-  {% endfor %}
-  RESTORE_GCODE_STATE NAME=clean_nozzle_state
-```
+!!! example "Complex macro example"
+    ```
+    [gcode_macro clean_nozzle]
+    gcode:
+      {% set wipe_count = 8 %}
+      SAVE_GCODE_STATE NAME=clean_nozzle_state
+      G90
+      G0 Z15 F300
+      {% for wipe in range(wipe_count) %}
+        {% for coordinate in [(275, 4),(235, 4)] %}
+          G0 X{coordinate[0]} Y{coordinate[1] + 0.25 * wipe} Z9.7 F12000
+        {% endfor %}
+      {% endfor %}
+      RESTORE_GCODE_STATE NAME=clean_nozzle_state
+    ```
 
 ### Macro parameters
 
 It is often useful to inspect parameters passed to the macro when
 it is called. These parameters are available via the `params`
-pseudo-variable. For example, if the macro:
+pseudo-variable.
 
-```
-[gcode_macro SET_PERCENT]
-gcode:
-  M117 Now at { params.VALUE|float * 100 }%
-```
+!!! example
+    If the macro:
 
-were invoked as `SET_PERCENT VALUE=.2` it would evaluate to `M117 Now
-at 20%`. Note that parameter names are always in upper-case when
-evaluated in the macro and are always passed as strings. If performing
-math then they must be explicitly converted to integers or floats.
+    ```
+    [gcode_macro SET_PERCENT]
+    gcode:
+      M117 Now at { params.VALUE|float * 100 }%
+    ```
+
+    were invoked as `SET_PERCENT VALUE=.2` it would evaluate to `M117 Now
+    at 20%`.
+!!! note
+    Parameter names are always in upper-case when
+    evaluated in the macro and are always passed as strings. If performing
+    math then they must be explicitly converted to integers or floats.
 
 It's common to use the Jinja2 `set` directive to use a default
-parameter and assign the result to a local name. For example:
+parameter and assign the result to a local name.
 
-```
-[gcode_macro SET_BED_TEMPERATURE]
-gcode:
-  {% set bed_temp = params.TEMPERATURE|default(40)|float %}
-  M140 S{bed_temp}
-```
+!!! example
+    ```
+    [gcode_macro SET_BED_TEMPERATURE]
+    gcode:
+      {% set bed_temp = params.TEMPERATURE|default(40)|float %}
+      M140 S{bed_temp}
+    ```
 
 ### The "rawparams" variable
 
@@ -141,42 +150,46 @@ showing how to override the `M117` command using `rawparams`.
 ### The "printer" Variable
 
 It is possible to inspect (and alter) the current state of the printer
-via the `printer` pseudo-variable. For example:
+via the `printer` pseudo-variable.
 
-```
-[gcode_macro slow_fan]
-gcode:
-  M106 S{ printer.fan.speed * 0.9 * 255}
-```
+!!! example
+    ```
+    [gcode_macro slow_fan]
+    gcode:
+      M106 S{ printer.fan.speed * 0.9 * 255}
+    ```
 
 Available fields are defined in the
 [Status Reference](Status_Reference.md) document.
 
-Important! Macros are first evaluated in entirety and only then are
-the resulting commands executed. If a macro issues a command that
-alters the state of the printer, the results of that state change will
-not be visible during the evaluation of the macro. This can also
-result in subtle behavior when a macro generates commands that call
-other macros, as the called macro is evaluated when it is invoked
-(which is after the entire evaluation of the calling macro).
+!!! important
+    Macros are first evaluated in entirety and only then are the resulting
+    commands executed. If a macro issues a command that alters the state of
+    the printer, the results of that state change will not be visible
+    during the evaluation of the macro. This can also result in subtle
+    behavior when a macro generates commands that call other macros, as the
+    called macro is evaluated when it is invoked (which is after the entire
+    evaluation of the calling macro).
 
 By convention, the name immediately following `printer` is the name of
 a config section. So, for example, `printer.fan` refers to the fan
 object created by the `[fan]` config section. There are some
 exceptions to this rule - notably the `gcode_move` and `toolhead`
 objects. If the config section contains spaces in it, then one can
-access it via the `[ ]` accessor - for example:
-`printer["generic_heater my_chamber_heater"].temperature`.
+access it via the `[ ]` accessor.
+!!! example
+    `printer["generic_heater my_chamber_heater"].temperature`.
 
-Note that the Jinja2 `set` directive can assign a local name to an
-object in the `printer` hierarchy. This can make macros more readable
-and reduce typing. For example:
-```
-[gcode_macro QUERY_HTU21D]
-gcode:
-    {% set sensor = printer["htu21d my_sensor"] %}
-    M117 Temp:{sensor.temperature} Humidity:{sensor.humidity}
-```
+!!! tip
+    Jinja2 `set` directive can assign a local name to an object in the
+    `printer` hierarchy. This can make macros more readable and reduce
+    typing. For example:
+    ```
+    [gcode_macro QUERY_HTU21D]
+    gcode:
+        {% set sensor = printer["htu21d my_sensor"] %}
+        M117 Temp:{sensor.temperature} Humidity:{sensor.humidity}
+    ```
 
 ## Actions
 
@@ -206,26 +219,26 @@ Available "action" commands:
 
 The SET_GCODE_VARIABLE command may be useful for saving state between
 macro calls. Variable names may not contain any upper case characters.
-For example:
 
-```
-[gcode_macro start_probe]
-variable_bed_temp: 0
-gcode:
-  # Save target temperature to bed_temp variable
-  SET_GCODE_VARIABLE MACRO=start_probe VARIABLE=bed_temp VALUE={printer.heater_bed.target}
-  # Disable bed heater
-  M140
-  # Perform probe
-  PROBE
-  # Call finish_probe macro at completion of probe
-  finish_probe
+!!! example
+    ```
+    [gcode_macro start_probe]
+    variable_bed_temp: 0
+    gcode:
+      # Save target temperature to bed_temp variable
+      SET_GCODE_VARIABLE MACRO=start_probe VARIABLE=bed_temp VALUE={printer.heater_bed.target}
+      # Disable bed heater
+      M140
+      # Perform probe
+      PROBE
+      # Call finish_probe macro at completion of probe
+      finish_probe
 
-[gcode_macro finish_probe]
-gcode:
-  # Restore temperature
-  M140 S{printer["gcode_macro start_probe"].bed_temp}
-```
+    [gcode_macro finish_probe]
+    gcode:
+      # Restore temperature
+      M140 S{printer["gcode_macro start_probe"].bed_temp}
+    ```
 
 Be sure to take the timing of macro evaluation and command execution
 into account when using SET_GCODE_VARIABLE.
@@ -235,20 +248,21 @@ into account when using SET_GCODE_VARIABLE.
 The [delayed_gcode] configuration option can be used to execute a delayed
 gcode sequence:
 
-```
-[delayed_gcode clear_display]
-gcode:
-  M117
+!!! example
+    ```
+    [delayed_gcode clear_display]
+    gcode:
+      M117
 
-[gcode_macro load_filament]
-gcode:
- G91
- G1 E50
- G90
- M400
- M117 Load Complete!
- UPDATE_DELAYED_GCODE ID=clear_display DURATION=10
-```
+    [gcode_macro load_filament]
+    gcode:
+    G91
+    G1 E50
+    G90
+    M400
+    M117 Load Complete!
+    UPDATE_DELAYED_GCODE ID=clear_display DURATION=10
+    ```
 
 When the `load_filament` macro above executes, it will display a
 "Load Complete!" message after the extrusion is finished.  The
@@ -257,36 +271,37 @@ to execute in 10 seconds.
 
 The `initial_duration` config option can be set to execute the
 delayed_gcode on printer startup.  The countdown begins when the
-printer enters the "ready" state.  For example, the below delayed_gcode
-will execute 5 seconds after the printer is ready, initializing
-the display with a "Welcome!" message:
+printer enters the "ready" state.
+!!! example
+    The below delayed_gcode
+    will execute 5 seconds after the printer is ready, initializing
+    the display with a "Welcome!" message:
 
-```
-[delayed_gcode welcome]
-initial_duration: 5.
-gcode:
-  M117 Welcome!
-```
+    ```
+    [delayed_gcode welcome]
+    initial_duration: 5.
+    gcode:
+      M117 Welcome!
+    ```
 
 Its possible for a delayed gcode to repeat by updating itself in
 the gcode option:
+!!! example
+    ```
+    [delayed_gcode report_temp]
+    initial_duration: 2.
+    gcode:
+      {action_respond_info("Extruder Temp: %.1f" % (printer.extruder0.temperature))}
+      UPDATE_DELAYED_GCODE ID=report_temp DURATION=2
+    ```
 
-```
-[delayed_gcode report_temp]
-initial_duration: 2.
-gcode:
-  {action_respond_info("Extruder Temp: %.1f" % (printer.extruder0.temperature))}
-  UPDATE_DELAYED_GCODE ID=report_temp DURATION=2
-```
+    The above delayed_gcode will send "// Extruder Temp: [ex0_temp]" to
+    Octoprint every 2 seconds.  This can be canceled with the following
+    gcode:
 
-The above delayed_gcode will send "// Extruder Temp: [ex0_temp]" to
-Octoprint every 2 seconds.  This can be canceled with the following
-gcode:
-
-
-```
-UPDATE_DELAYED_GCODE ID=report_temp DURATION=0
-```
+    ```
+    UPDATE_DELAYED_GCODE ID=report_temp DURATION=0
+    ```
 
 ## Menu templates
 
@@ -326,23 +341,24 @@ the top of the macro:
 {% set svv = printer.save_variables.variables %}
 ```
 
-As an example, it could be used to save the state of 2-in-1-out hotend
-and when starting a print ensure that the active extruder is used,
-instead of T0:
+!!! example
+    It could be used to save the state of 2-in-1-out hotend
+    and when starting a print ensure that the active extruder is used,
+    instead of T0:
 
-```
-[gcode_macro T1]
-gcode:
-  ACTIVATE_EXTRUDER extruder=extruder1
-  SAVE_VARIABLE VARIABLE=currentextruder VALUE='"extruder1"'
+    ```
+    [gcode_macro T1]
+    gcode:
+      ACTIVATE_EXTRUDER extruder=extruder1
+      SAVE_VARIABLE VARIABLE=currentextruder VALUE='"extruder1"'
 
-[gcode_macro T0]
-gcode:
-  ACTIVATE_EXTRUDER extruder=extruder
-  SAVE_VARIABLE VARIABLE=currentextruder VALUE='"extruder"'
+    [gcode_macro T0]
+    gcode:
+      ACTIVATE_EXTRUDER extruder=extruder
+      SAVE_VARIABLE VARIABLE=currentextruder VALUE='"extruder"'
 
-[gcode_macro START_GCODE]
-gcode:
-  {% set svv = printer.save_variables.variables %}
-  ACTIVATE_EXTRUDER extruder={svv.currentextruder}
-```
+    [gcode_macro START_GCODE]
+    gcode:
+      {% set svv = printer.save_variables.variables %}
+      ACTIVATE_EXTRUDER extruder={svv.currentextruder}
+    ```

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -29,9 +29,10 @@ resistor should be enabled for the pin. If the micro-controller
 supports pull-down resistors then an input pin may alternatively be
 preceded by `~`.
 
-Note, some config sections may "create" additional pins. Where this
-occurs, the config section defining the pins must be listed in the
-config file before any sections using those pins.
+!!! note: "Note: Additional pins"
+    Some config sections may "create" additional pins. Where this occurs,
+    the config section defining the pins must be listed in the config file
+    before any sections using those pins.
 
 ### [mcu]
 
@@ -1153,7 +1154,10 @@ extended [G-Code command](G-Codes.md#z_tilt) becomes available.
 Moving gantry leveling using 4 independently controlled Z motors.
 Corrects hyperbolic parabola effects (potato chip) on moving gantry
 which is more flexible.
-WARNING: Using this on a moving bed may lead to undesirable results.
+
+!!! warning
+    Using this on a moving bed may lead to undesirable results.
+
 If this section is present then a QUAD_GANTRY_LEVEL extended G-Code
 command becomes available. This routine assumes the following Z motor
 configuration:
@@ -2326,12 +2330,12 @@ sensor_pin:
 ### BMP280/BME280/BME680 temperature sensor
 
 BMP280/BME280/BME680 two wire interface (I2C) environmental sensors.
-Note that these sensors are not intended for use with extruders and
-heater beds, but rather for monitoring ambient temperature (C),
-pressure (hPa), relative humidity and in case of the BME680 gas level.
-See [sample-macros.cfg](../config/sample-macros.cfg) for a gcode_macro
-that may be used to report pressure and humidity in addition to
-temperature.
+!!! note
+    These sensors are not intended for use with extruders and heater beds,
+    but rather for monitoring ambient temperature (C), pressure (hPa),
+    relative humidity and in case of the BME680 gas level. See
+    [sample-macros.cfg](../config/sample-macros.cfg) for a gcode_macro that
+    may be used to report pressure and humidity in addition to temperature.
 
 ```
 sensor_type: BME280
@@ -2741,11 +2745,11 @@ Neopixel (aka WS2812) LED support (one may define any number of
 sections with a "neopixel" prefix). See the
 [command reference](G-Codes.md#led) for more information.
 
-Note that the [linux mcu](RPi_microcontroller.md) implementation does
-not currently support directly connected neopixels. The current design
-using the Linux kernel interface does not allow this scenario because
-the kernel GPIO interface is not fast enough to provide the required
-pulse rates.
+!!! note "Note: [Linux mcu](RPi_microcontroller.md)"
+    [Linux mcu](RPi_microcontroller.md) implementation does not currently
+    support directly connected neopixels. The current design using the
+    Linux kernel interface does not allow this scenario because the kernel
+    GPIO interface is not fast enough to provide the required pulse rates.
 
 ```
 [neopixel my_neopixel]
@@ -4311,12 +4315,13 @@ SPI bus.
 The following parameters are generally available for devices using an
 I2C bus.
 
-Note that Klipper's current micro-controller support for i2c is
-generally not tolerant to line noise. Unexpected errors on the i2c
-wires may result in Klipper raising a run-time error. Klipper's
-support for error recovery varies between each micro-controller type.
-It is generally recommended to only use i2c devices that are on the
-same printed circuit board as the micro-controller.
+!!! note "Note: Line noise"
+    Klipper's current micro-controller support for i2c is generally not
+    tolerant to line noise. Unexpected errors on the i2c wires may result
+    in Klipper raising a run-time error. Klipper's support for error
+    recovery varies between each micro-controller type. It is generally
+    recommended to only use i2c devices that are on the same printed
+    circuit board as the micro-controller.
 
 Most Klipper micro-controller implementations only support an
 `i2c_speed` of 100000. The Klipper "linux" micro-controller supports a

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -8,6 +8,12 @@ to cut-and-paste them into a printer config file. See the
 [installation document](Installation.md) for information on setting up
 Klipper and choosing an initial config file.
 
+!!! warning "Compatibility"
+    All sections and settings with descriptions prefixed with a ⚠️ symbol
+    are specific to Danger Klipper. Be aware that if you use these modules
+    and settings, your configuration will no longer work with mainline
+    Klipper.
+
 ## Micro-controller configuration
 
 ### Format of micro-controller pin names
@@ -1796,8 +1802,8 @@ z_offset:
 #   issue any commands here that move the toolhead. The default is to
 #   not run any special G-Code commands on deactivation.
 #drop_first_result: False
-#   Set to `True` will probe one extra time and remove the first
-#   sample from calculation. This can improve probe accuracy for 
+#   ⚠️ Set to `True` will probe one extra time and remove the first
+#   sample from calculation. This can improve probe accuracy for
 #   printers that have an outlier first sample.
 ```
 

--- a/docs/Config_checks.md
+++ b/docs/Config_checks.md
@@ -138,8 +138,9 @@ found in other firmwares or in the example configuration files often
 work poorly).
 
 To calibrate the extruder, navigate to the OctoPrint terminal tab and
-run the PID_CALIBRATE command. For example: `PID_CALIBRATE
-HEATER=extruder TARGET=170`
+run the PID_CALIBRATE command.
+!!! example
+    `PID_CALIBRATE HEATER=extruder TARGET=170`
 
 At the completion of the tuning test run `SAVE_CONFIG` to update the
 printer.cfg file the new PID settings.

--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -88,10 +88,11 @@ Klipper supports logging its internal motion history, which can be
 later analyzed. To use this feature, Klipper must be started with the
 [API Server](API_Server.md) enabled.
 
-Data logging is enabled with the `data_logger.py` tool. For example:
-```
-~/klipper/scripts/motan/data_logger.py /tmp/klippy_uds mylog
-```
+Data logging is enabled with the `data_logger.py` tool.
+!!! example
+    ```
+    ~/klipper/scripts/motan/data_logger.py /tmp/klippy_uds mylog
+    ```
 
 This command will connect to the Klipper API Server, subscribe to
 status and motion information, and log the results. Two files are
@@ -115,27 +116,30 @@ a recent version of [Python](https://python.org) and
 [Matplotlib](https://matplotlib.org/) installed.
 
 Graphs can be generated with a command like the following:
-```
-~/klipper/scripts/motan/motan_graph.py mylog -o mygraph.png
-```
+!!! example
+    ```
+    ~/klipper/scripts/motan/motan_graph.py mylog -o mygraph.png
+    ```
 
 One can use the `-g` option to specify the datasets to graph (it takes
-a Python literal containing a list of lists). For example:
-```
-~/klipper/scripts/motan/motan_graph.py mylog -g '[["trapq(toolhead,velocity)"], ["trapq(toolhead,accel)"]]'
-```
+a Python literal containing a list of lists).
+!!! example
+    ```
+    ~/klipper/scripts/motan/motan_graph.py mylog -g '[["trapq(toolhead,velocity)"], ["trapq(toolhead,accel)"]]'
+    ```
 
-The list of available datasets can be found using the `-l` option -
-for example:
-```
-~/klipper/scripts/motan/motan_graph.py -l
-```
+The list of available datasets can be found using the `-l` option.
+!!! example
+    ```
+    ~/klipper/scripts/motan/motan_graph.py -l
+    ```
 
 It is also possible to specify matplotlib plot options for each
 dataset:
-```
-~/klipper/scripts/motan/motan_graph.py mylog -g '[["trapq(toolhead,velocity)?color=red&alpha=0.4"]]'
-```
+!!! example
+    ```
+    ~/klipper/scripts/motan/motan_graph.py mylog -g '[["trapq(toolhead,velocity)?color=red&alpha=0.4"]]'
+    ```
 Many matplotlib options are available; some examples are "color",
 "label", "alpha", and "linestyle".
 
@@ -244,11 +248,12 @@ Klipper (run `make`) and then start the simulation with:
 ```
 PYTHONPATH=/path/to/simulavr/build/pysimulavr/ ./scripts/avrsim.py out/klipper.elf
 ```
-Note that if you have installed python3-simulavr system-wide, you do
-not need to set `PYTHONPATH`, and can simply run the simulator as
-```
-./scripts/avrsim.py out/klipper.elf
-```
+!!! note
+    If you have installed python3-simulavr system-wide, you do not need to
+    set `PYTHONPATH`, and can simply run the simulator as
+    ```
+    ./scripts/avrsim.py out/klipper.elf
+    ```
 
 Then, with simulavr running in another window, one can run the
 following to read gcode from a file (eg, "test.gcode"), process it

--- a/docs/Delta_Calibrate.md
+++ b/docs/Delta_Calibrate.md
@@ -245,6 +245,7 @@ is important to obtain good delta calibration prior to enabling a bed
 mesh. Running bed mesh with poor delta calibration will result in
 confusing and poor results.
 
-Note that performing delta calibration will invalidate any previously
-obtained bed mesh. After performing a new delta calibration be sure to
-rerun BED_MESH_CALIBRATE.
+!!! note
+    Performing delta calibration will invalidate any previously obtained
+    bed mesh. After performing a new delta calibration be sure to rerun
+    BED_MESH_CALIBRATE.

--- a/docs/Example_Configs.md
+++ b/docs/Example_Configs.md
@@ -4,9 +4,10 @@ This document contains guidelines for contributing an example Klipper
 configuration to the Klipper github repository (located in the
 [config directory](../config/)).
 
-Note that the
-[Klipper Community Discourse server](https://community.klipper3d.org)
-is also a useful resource for finding and sharing config files.
+!!! tip
+    The [Klipper Community Discourse
+    server](https://community.klipper3d.org) is also a useful resource for
+    finding and sharing config files.
 
 ## Guidelines
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -80,12 +80,12 @@ need to be configured in the micro-controller (during **make
 menuconfig**) and that updated code will need to be compiled and
 flashed to the micro-controller. The Klipper printer.cfg file will
 also need to be updated to match that baud rate (see the
-[config reference](Config_Reference.md#mcu) for details).  For
-example:
-```
-[mcu]
-baud: 250000
-```
+[config reference](Config_Reference.md#mcu) for details).
+!!! example
+    ```
+    [mcu]
+    baud: 250000
+    ```
 
 The baud rate shown on the OctoPrint web page has no impact on the
 internal Klipper micro-controller baud rate. Always set the OctoPrint
@@ -132,12 +132,13 @@ computing task (such as defragmenting a hard drive, 3d rendering,
 heavy swapping, etc.), then it may cause Klipper to report print
 errors.
 
-Note: If you are not using an OctoPi image, be aware that several
-Linux distributions enable a "ModemManager" (or similar) package that
-can disrupt serial communication. (Which can cause Klipper to report
-seemingly random "Lost communication with MCU" errors.) If you install
-Klipper on one of these distributions you may need to disable that
-package.
+!!! important "Important: ModemManager and serial"
+    If you are not using an OctoPi image, be aware that several Linux
+    distributions enable a "ModemManager" (or similar) package that can
+    disrupt serial communication. (Which can cause Klipper to report
+    seemingly random "Lost communication with MCU" errors.) If you install
+    Klipper on one of these distributions you may need to disable that
+    package.
 
 ## Can I run multiple instances of Klipper on the same host machine?
 
@@ -149,10 +150,11 @@ scripts ultimately cause the following Unix command to be run:
 ```
 One can run multiple instances of the above command as long as each
 instance has its own printer config file, its own log file, and its
-own pseudo-tty. For example:
-```
-~/klippy-env/bin/python ~/klipper/klippy/klippy.py ~/printer2.cfg -l /tmp/klippy2.log -I /tmp/printer2
-```
+own pseudo-tty.
+!!! example
+    ```
+    ~/klippy-env/bin/python ~/klipper/klippy/klippy.py ~/printer2.cfg -l /tmp/klippy2.log -I /tmp/printer2
+    ```
 
 If you choose to do this, you will need to implement the necessary
 start, stop, and installation scripts (if any). The
@@ -390,12 +392,13 @@ accelerations and speeds without needing to actually print something
 and waste filament: just run some high-speed moves in between the
 `GET_POSITION` commands.
 
-Note that endstop switches themselves tend to trigger at slightly
-different positions, so a difference of a couple of microsteps is
-likely the result of endstop inaccuracies. A stepper motor itself can
-only lose steps in increments of 4 full steps. (So, if one is using 16
-microsteps, then a lost step on the stepper would result in the "mcu:"
-step counter being off by a multiple of 64 microsteps.)
+!!! note
+    Endstop switches themselves tend to trigger at slightly different
+    positions, so a difference of a couple of microsteps is likely the
+    result of endstop inaccuracies. A stepper motor itself can only lose
+    steps in increments of 4 full steps. (So, if one is using 16
+    microsteps, then a lost step on the stepper would result in the "mcu:"
+    step counter being off by a multiple of 64 microsteps.)
 
 ## Why does Klipper report errors? I lost my print!
 
@@ -444,18 +447,17 @@ git pull
 ~/klipper/scripts/install-octopi.sh
 ```
 
-Then one can recompile and flash the micro-controller code. For
-example:
+Then one can recompile and flash the micro-controller code.
+!!! example
+    ```
+    make menuconfig
+    make clean
+    make
 
-```
-make menuconfig
-make clean
-make
-
-sudo service klipper stop
-make flash FLASH_DEVICE=/dev/ttyACM0
-sudo service klipper start
-```
+    sudo service klipper stop
+    make flash FLASH_DEVICE=/dev/ttyACM0
+    sudo service klipper start
+    ```
 
 However, it's often the case that only the host software changes. In
 this case, one can update and restart just the host software with:
@@ -474,9 +476,10 @@ If any errors persist then double check the
 [config changes](Config_Changes.md) document, as you may need to
 modify the printer configuration.
 
-Note that the RESTART and FIRMWARE_RESTART g-code commands do not load
-new software - the above "sudo service klipper restart" and "make
-flash" commands are needed for a software change to take effect.
+!!! important
+    RESTART and FIRMWARE_RESTART g-code commands do not load new software -
+    the above "sudo service klipper restart" and "make flash" commands are
+    needed for a software change to take effect.
 
 ## How do I uninstall Klipper?
 
@@ -484,9 +487,9 @@ On the firmware end, nothing special needs to happen. Just follow the
 flashing directions for the new firmware.
 
 On the raspberry pi end, an uninstall script is available in
-[scripts/klipper-uninstall.sh](../scripts/klipper-uninstall.sh). For
-example:
-```
-sudo ~/klipper/scripts/klipper-uninstall.sh
-rm -rf ~/klippy-env ~/klipper
-```
+[scripts/klipper-uninstall.sh](../scripts/klipper-uninstall.sh).
+!!! example
+    ```
+    sudo ~/klipper/scripts/klipper-uninstall.sh
+    rm -rf ~/klippy-env ~/klipper
+    ```

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -68,6 +68,12 @@ follows the section names specified in the
 [printer configuration file](Config_Reference.md). Note that some
 modules are automatically loaded.
 
+!!! warning "Compatibility"
+    All command sections prefixed with a ⚠️ symbol are specific to Danger
+    Klipper. Be aware that if you use these commands in your macro or
+    slicer startup gcode, your setup will no longer work with mainline
+    Klipper.
+
 ### [adxl345]
 
 The following commands are available when an

--- a/docs/Manual_Level.md
+++ b/docs/Manual_Level.md
@@ -59,14 +59,14 @@ bed is a set distance from the nozzle. Klipper has a tool to assist
 with this. In order to use the tool it is necessary to specify each
 screw XY location.
 
-This is done by creating a `[bed_screws]` config section. For example,
-it might look something similar to:
-```
-[bed_screws]
-screw1: 100, 50
-screw2: 100, 150
-screw3: 150, 100
-```
+This is done by creating a `[bed_screws]` config section.
+!!! example
+    ```
+    [bed_screws]
+    screw1: 100, 50
+    screw2: 100, 150
+    screw3: 150, 100
+    ```
 
 If a bed screw is under the bed, then specify the XY position directly
 above the screw. If the screw is outside the bed then specify an XY
@@ -122,17 +122,17 @@ directly at C. It is thus possible to make an improved C screw
 adjustment when the nozzle is at position D.
 
 To enable this feature, one would determine the additional nozzle
-coordinates and add them to the config file. For example, it might
-look like:
-```
-[bed_screws]
-screw1: 100, 50
-screw1_fine_adjust: 0, 0
-screw2: 100, 150
-screw2_fine_adjust: 300, 300
-screw3: 150, 100
-screw3_fine_adjust: 0, 100
-```
+coordinates and add them to the config file.
+!!! example
+    ```
+    [bed_screws]
+    screw1: 100, 50
+    screw1_fine_adjust: 0, 0
+    screw2: 100, 150
+    screw2_fine_adjust: 300, 300
+    screw3: 150, 100
+    screw3_fine_adjust: 0, 100
+    ```
 
 When this feature is enabled, the `BED_SCREWS_ADJUST` tool will first
 prompt for coarse adjustments directly above each screw position, and
@@ -147,38 +147,39 @@ use it you must have a Z probe (BL Touch, Inductive sensor, etc).
 
 To enable this feature, one would determine the nozzle coordinates
 such that the Z probe is above the screws, and then add them to the
-config file. For example, it might look like:
-
-```
-[screws_tilt_adjust]
-screw1: -5, 30
-screw1_name: front left screw
-screw2: 155, 30
-screw2_name: front right screw
-screw3: 155, 190
-screw3_name: rear right screw
-screw4: -5, 190
-screw4_name: rear left screw
-horizontal_move_z: 10.
-speed: 50.
-screw_thread: CW-M3
-```
+config file.
+!!! example
+    ```
+    [screws_tilt_adjust]
+    screw1: -5, 30
+    screw1_name: front left screw
+    screw2: 155, 30
+    screw2_name: front right screw
+    screw3: 155, 190
+    screw3_name: rear right screw
+    screw4: -5, 190
+    screw4_name: rear left screw
+    horizontal_move_z: 10.
+    speed: 50.
+    screw_thread: CW-M3
+    ```
 
 The screw1 is always the reference point for the others, so the system
 assumes that screw1 is at the correct height. Always run `G28` first
 and then run `SCREWS_TILT_CALCULATE` - it should produce output
 similar to:
-```
-Send: G28
-Recv: ok
-Send: SCREWS_TILT_CALCULATE
-Recv: // 01:20 means 1 full turn and 20 minutes, CW=clockwise, CCW=counter-clockwise
-Recv: // front left screw (base) : x=-5.0, y=30.0, z=2.48750
-Recv: // front right screw : x=155.0, y=30.0, z=2.36000 : adjust CW 01:15
-Recv: // rear right screw : y=155.0, y=190.0, z=2.71500 : adjust CCW 00:50
-Recv: // read left screw : x=-5.0, y=190.0, z=2.47250 : adjust CW 00:02
-Recv: ok
-```
+!!! example
+    ```
+    Send: G28
+    Recv: ok
+    Send: SCREWS_TILT_CALCULATE
+    Recv: // 01:20 means 1 full turn and 20 minutes, CW=clockwise, CCW=counter-clockwise
+    Recv: // front left screw (base) : x=-5.0, y=30.0, z=2.48750
+    Recv: // front right screw : x=155.0, y=30.0, z=2.36000 : adjust CW 01:15
+    Recv: // rear right screw : y=155.0, y=190.0, z=2.71500 : adjust CCW 00:50
+    Recv: // read left screw : x=-5.0, y=190.0, z=2.47250 : adjust CW 00:02
+    Recv: ok
+    ```
 
 This means that:
 - front left screw is the reference point you must not change it.

--- a/docs/Measuring_Resonances.md
+++ b/docs/Measuring_Resonances.md
@@ -63,15 +63,17 @@ An example of mounting ADXL345 on the SmartEffector:
 
 ![ADXL345 on SmartEffector](img/adxl345-mount.jpg)
 
-Note that on a bed slinger printer one must design 2 mounts: one for the
-toolhead and one for the bed, and run the measurements twice. See the
-corresponding [section](#bed-slinger-printers) for more details.
+!!! note
+    On a bed slinger printer one must design 2 mounts: one for the toolhead
+    and one for the bed, and run the measurements twice. See the
+    corresponding [section](#bed-slinger-printers) for more details.
 
-**Attention:** make sure the accelerometer and any screws that hold it in
-place do not touch any metal parts of the printer. Basically, the mount must
-be designed such as to ensure the electrical isolation of the accelerometer
-from the printer frame. Failing to ensure that can create a ground loop in
-the system that may damage the electronics.
+!!! danger
+    Make sure the accelerometer and any screws that hold it in place do not
+    touch any metal parts of the printer. Basically, the mount must be
+    designed such as to ensure the electrical isolation of the
+    accelerometer from the printer frame. Failing to ensure that can create
+    a ground loop in the system that may damage the electronics.
 
 ### Software installation
 
@@ -87,10 +89,11 @@ Next, in order to install NumPy in the Klipper environment, run the command:
 ```
 ~/klippy-env/bin/pip install -v numpy
 ```
-Note that, depending on the performance of the CPU, it may take *a lot*
-of time, up to 10-20 minutes. Be patient and wait for the completion of
-the installation. On some occasions, if the board has too little RAM
-the installation may fail and you will need to enable swap.
+!!! note
+    Depending on the performance of the CPU, it may take *a lot* of time,
+    up to 10-20 minutes. Be patient and wait for the completion of the
+    installation. On some occasions, if the board has too little RAM the
+    installation may fail and you will need to enable swap.
 
 Afterwards, check and follow the instructions in the
 [RPi Microcontroller document](RPi_microcontroller.md) to setup the
@@ -170,21 +173,24 @@ Now you can run some real-life tests. Run the following command:
 ```
 TEST_RESONANCES AXIS=X
 ```
-Note that it will create vibrations on X axis. It will also disable input
-shaping if it was enabled previously, as it is not valid to run the resonance
-testing with the input shaper enabled.
+!!! info
+    It will create vibrations on X axis. It will also disable input shaping
+    if it was enabled previously, as it is not valid to run the resonance
+    testing with the input shaper enabled.
 
-**Attention!** Be sure to observe the printer for the first time, to make sure
-the vibrations do not become too violent (`M112` command can be used to abort
-the test in case of emergency; hopefully it will not come to this though).
-If the vibrations do get too strong, you can attempt to specify a lower than the
-default value for `accel_per_hz` parameter in `[resonance_tester]` section, e.g.
-```
-[resonance_tester]
-accel_chip: adxl345
-accel_per_hz: 50  # default is 75
-probe_points: ...
-```
+!!! warning
+    Be sure to observe the printer for the first time, to make sure the
+    vibrations do not become too violent (`M112` command can be used to
+    abort the test in case of emergency; hopefully it will not come to this
+    though). If the vibrations do get too strong, you can attempt to
+    specify a lower than the default value for `accel_per_hz` parameter in
+    `[resonance_tester]` section, e.g.
+    ```
+    [resonance_tester]
+    accel_chip: adxl345
+    accel_per_hz: 50  # default is 75
+    probe_points: ...
+    ```
 
 If it works for X axis, run for Y axis as well:
 ```
@@ -233,10 +239,11 @@ or you can choose some other configuration yourself based on the generated
 charts: peaks in the power spectral density on the charts correspond to
 the resonance frequencies of the printer.
 
-Note that alternatively you can run the input shaper autocalibration
-from Klipper [directly](#input-shaper-auto-calibration), which can be
-convenient, for example, for the input shaper
-[re-calibration](#input-shaper-re-calibration).
+!!! info
+    Alternatively you can run the input shaper autocalibration from Klipper
+    [directly](#input-shaper-auto-calibration), which can be convenient,
+    for example, for the input shaper
+    [re-calibration](#input-shaper-re-calibration).
 
 ### Bed-slinger printers
 
@@ -295,13 +302,16 @@ Fitted shaper '3hump_ei' frequency = 48.0 Hz (vibrations = 0.0%, smoothing ~= 0.
 To avoid too much smoothing with '3hump_ei', suggested max_accel <= 1500 mm/sec^2
 Recommended shaper is 2hump_ei @ 45.2 Hz
 ```
-Note that the reported `smoothing` values are some abstract projected values.
-These values can be used to compare different configurations: the higher the
-value, the more smoothing a shaper will create. However, these smoothing scores
-do not represent any real measure of smoothing, because the actual smoothing
-depends on [`max_accel`](#selecting-max-accel) and `square_corner_velocity`
-parameters. Therefore, you should print some test prints to see how much
-smoothing exactly a chosen configuration creates.
+
+!!! tip
+    The reported `smoothing` values are some abstract projected values.
+    These values can be used to compare different configurations: the
+    higher the value, the more smoothing a shaper will create. However,
+    these smoothing scores do not represent any real measure of smoothing,
+    because the actual smoothing depends on
+    [`max_accel`](#selecting-max-accel) and `square_corner_velocity`
+    parameters. Therefore, you should print some test prints to see how
+    much smoothing exactly a chosen configuration creates.
 
 In the example above the suggested shaper parameters are not bad, but what if
 you want to get less smoothing on the X axis? You can try to limit the maximum
@@ -341,17 +351,18 @@ at the lowest resonance frequencies (which are, typically, also more prominently
 visible in prints). So, always double-check the projected remaining vibrations
 reported by the script and make sure they are not too high.
 
-Note that if you chose a good `max_smoothing` value for both of your axes, you
-can store it in the `printer.cfg` as
-```
-[resonance_tester]
-accel_chip: ...
-probe_points: ...
-max_smoothing: 0.25  # an example
-```
-Then, if you [rerun](#input-shaper-re-calibration) the input shaper auto-tuning
-using `SHAPER_CALIBRATE` Klipper command in the future, it will use the stored
-`max_smoothing` value as a reference.
+!!! tip
+    If you chose a good `max_smoothing` value for both of your axes, you
+    can store it in the `printer.cfg` as
+    ```
+    [resonance_tester]
+    accel_chip: ...
+    probe_points: ...
+    max_smoothing: 0.25  # an example
+    ```
+    Then, if you [rerun](#input-shaper-re-calibration) the input shaper
+    auto-tuning using `SHAPER_CALIBRATE` Klipper command in the future, it
+    will use the stored `max_smoothing` value as a reference.
 
 ### Selecting max_accel
 
@@ -473,21 +484,25 @@ supplying `AXIS=` parameter, like
 SHAPER_CALIBRATE AXIS=X
 ```
 
-**Warning!** It is not advisable to run the shaper autocalibration very
-frequently (e.g. before every print, or every day). In order to determine
-resonance frequencies, autocalibration creates intensive vibrations on each of
-the axes. Generally, 3D printers are not designed to withstand a prolonged
-exposure to vibrations near the resonance frequencies. Doing so may increase
-wear of the printer components and reduce their lifespan. There is also an
-increased risk of some parts unscrewing or becoming loose. Always check that
-all parts of the printer (including the ones that may normally not move) are
-securely fixed in place after each auto-tuning.
+!!! warning
+    It is not advisable to run the shaper autocalibration very frequently
+    (e.g. before every print, or every day). In order to determine
+    resonance frequencies, autocalibration creates intensive vibrations on
+    each of the axes. Generally, 3D printers are not designed to withstand
+    a prolonged exposure to vibrations near the resonance frequencies.
+    Doing so may increase wear of the printer components and reduce their
+    lifespan. There is also an increased risk of some parts unscrewing or
+    becoming loose. Always check that all parts of the printer (including
+    the ones that may normally not move) are securely fixed in place after
+    each auto-tuning.
 
-Also, due to some noise in measurements, it is possible that the tuning results
-will be slightly different from one calibration run to another one. Still, it
-is not expected that the noise will affect the print quality too much.
-However, it is still advised to double-check the suggested parameters, and
-print some test prints before using them to confirm they are good.
+!!! info
+    Also, due to some noise in measurements, it is possible that the tuning
+    results will be slightly different from one calibration run to another
+    one. Still, it is not expected that the noise will affect the print
+    quality too much. However, it is still advised to double-check the
+    suggested parameters, and print some test prints before using them to
+    confirm they are good.
 
 ## Offline processing of the accelerometer data
 
@@ -526,8 +541,9 @@ mode. The graph_accelerometer.py script supports several modes of operation:
   `-a x`, `-a y` or `-a z` parameter (if none specified, the sum of vibrations
   for all axes is used).
 
-Note that graph_accelerometer.py script supports only the raw_data\*.csv files
-and not resonances\*.csv or calibration_data\*.csv files.
+!!! important
+    graph_accelerometer.py script supports only the raw_data\*.csv files
+    and not resonances\*.csv or calibration_data\*.csv files.
 
 For example,
 ```

--- a/docs/Multi_MCU_Homing.md
+++ b/docs/Multi_MCU_Homing.md
@@ -35,8 +35,9 @@ Should Klipper detect a communication issue between micro-controllers
 during multi-mcu homing then it will raise a "Communication timeout
 during homing" error.
 
-Note that an axis with multiple steppers (eg, `stepper_z` and
-`stepper_z1`) need to be on the same micro-controller in order to use
-multi-mcu homing. For example, if an endstop is on a separate
-micro-controller from `stepper_z` then `stepper_z1` must be on the
-same micro-controller as `stepper_z`.
+!!! important "Axis with multiple steppers"
+    Axis with multiple steppers (eg, `stepper_z` and `stepper_z1`) need to
+    be on the same micro-controller in order to use multi-mcu homing. For
+    example, if an endstop is on a separate micro-controller from
+    `stepper_z` then `stepper_z1` must be on the same micro-controller as
+    `stepper_z`.

--- a/docs/Probe_Calibrate.md
+++ b/docs/Probe_Calibrate.md
@@ -72,9 +72,9 @@ results to the config file with:
 SAVE_CONFIG
 ```
 
-Note that if a change is made to the printer's motion system, hotend
-position, or probe location then it will invalidate the results of
-PROBE_CALIBRATE.
+!!! important
+    If a change is made to the printer's motion system, hotend position, or
+    probe location then it will invalidate the results of PROBE_CALIBRATE.
 
 If the probe has an X or Y offset and the bed tilt is changed (eg, by
 adjusting bed screws, running DELTA_CALIBRATE, running Z_TILT_ADJUST,

--- a/docs/RPi_microcontroller.md
+++ b/docs/RPi_microcontroller.md
@@ -13,9 +13,10 @@ directly use the GPIOs and the buses (i2c, spi) of the RPi inside
 klipper without using Octoprint plugins (if used) or external programs
 giving the ability to control everything within the print GCODE.
 
-**Warning**: If your platform is a _Beaglebone_ and you have correctly
-followed the installation steps, the linux mcu is already installed
-and configured for your system.
+!!! important
+    If your platform is a _Beaglebone_ and you have correctly followed the
+    installation steps, the linux mcu is already installed and configured
+    for your system.
 
 ## Install the rc script
 
@@ -109,8 +110,9 @@ The chosen pin can thus be used within the configuration as
 `gpiodetect` command and **o** is the line number seen by the`
 gpioinfo` command.
 
-***Warning:*** only gpio marked as `unused` can be used. It is not
-possible for a _line_ to be used by multiple processes simultaneously.
+!!! warning
+    Only gpio marked as `unused` can be used. It is not possible for a
+    _line_ to be used by multiple processes simultaneously.
 
 For example on a RPi 3B+ where klipper use the GPIO20 for a switch:
 ```

--- a/docs/Resonance_Compensation.md
+++ b/docs/Resonance_Compensation.md
@@ -84,10 +84,12 @@ First, measure the **ringing frequency**.
     velocity, so the frequency is 100 * 6 / 12.14 ≈ 49.4 Hz.
 11. Do (8) - (10) for Y mark as well.
 
-Note that ringing on the test print should follow the pattern of the curved
-notches, as in the picture above. If it doesn't, then this defect is not really
-a ringing and has a different origin - either mechanical, or an extruder issue.
-It should be fixed first before enabling and tuning input shapers.
+!!! important "Possible confusion with other ringing like artifacts"
+    Ringing on the test print should follow the pattern of the curved
+    notches, as in the picture above. If it doesn't, then this defect is
+    not really a ringing and has a different origin - either mechanical, or
+    an extruder issue. It should be fixed first before enabling and tuning
+    input shapers.
 
 If the measurements are not reliable because, say, the distance
 between the oscillations is not stable, it might mean that the printer has
@@ -102,25 +104,30 @@ differences in frequencies at different positions along the sides of the test
 model and at different heights. You can calculate the average ringing
 frequencies over X and Y axes if that is the case.
 
-If the measured ringing frequency is very low (below approx 20-25 Hz), it might
-be a good idea to invest into stiffening the printer or decreasing the moving
-mass - depending on what is applicable in your case - before proceeding with
-further input shaping tuning, and re-measuring the frequencies afterwards. For
-many popular printer models there are often some solutions available already.
+!!! tip "Tip: Low ringing frequency"
+    If the measured ringing frequency is very low (below approx 20-25 Hz),
+    it might be a good idea to invest into stiffening the printer or
+    decreasing the moving mass - depending on what is applicable in your
+    case - before proceeding with further input shaping tuning, and
+    re-measuring the frequencies afterwards. For many popular printer
+    models there are often some solutions available already.
 
-Note that the ringing frequencies can change if the changes are made to the
-printer that affect the moving mass or change the stiffness of the system,
-for example:
+!!! important "Important: Effects of hardware modifications"
+    Ringing frequencies can change if the changes are made to the printer
+    that affect the moving mass or change the stiffness of the system, for
+    example:
 
-* Some tools are installed, removed or replaced on the toolhead that change
- its mass, e.g. a new (heavier or lighter) stepper motor for direct extruder
- or a new hotend is installed, heavy fan with a duct is added, etc.
-* Belts are tightened.
-* Some addons to increase frame rigidity are installed.
-* Different bed is installed on a bed-slinger printer, or glass added, etc.
+    * Some tools are installed, removed or replaced on the toolhead that
+    change its mass, e.g. a new (heavier or lighter) stepper motor for
+    direct extruder or a new hotend is installed, heavy fan with a duct is
+    added, etc.
+    * Belts are tightened.
+    * Some addons to increase frame rigidity are installed.
+    * Different bed is installed on a bed-slinger printer, or glass added,
+    etc.
 
-If such changes are made, it is a good idea to at least measure the ringing
-frequencies to see if they have changed.
+    **If such changes are made, it is a good idea to at least measure the
+    ringing frequencies to see if they have changed.**
 
 ### Input shaper configuration
 
@@ -180,21 +187,24 @@ shaper_freq_y: ...
 shaper_type: mzv
 ```
 
-A few notes on shaper selection:
 
-* EI shaper may be more suited for bed slinger printers (if the resonance
- frequency and resulting smoothing allows): as more filament is deposited
- on the moving bed, the mass of the bed increases and the resonance frequency
- will decrease. Since EI shaper is more robust to resonance frequency
- changes, it may work better when printing large parts.
-* Due to the nature of delta kinematics, resonance frequencies can differ a
- lot in different parts of the build volume. Therefore, EI shaper can be a
- better fit for delta printers rather than MZV or ZV, and should be
- considered for the use. If the resonance frequency is sufficiently large
- (more than 50-60 Hz), then one can even attempt to test 2HUMP_EI shaper
- (by running the suggested test above with
- `SET_INPUT_SHAPER SHAPER_TYPE=2HUMP_EI`), but check the considerations in
- the [section below](#selecting-max_accel) before enabling it.
+!!! note "Note: Bed slingers"
+    EI shaper may be more suited for bed slinger printers (if the resonance
+    frequency and resulting smoothing allows): as more filament is
+    deposited on the moving bed, the mass of the bed increases and the
+    resonance frequency will decrease. Since EI shaper is more robust to
+    resonance frequency changes, it may work better when printing large
+    parts.
+
+!!! note "Note: Delta kinematics"
+    Due to the nature of delta kinematics, resonance frequencies can differ
+    a lot in different parts of the build volume. Therefore, EI shaper can
+    be a better fit for delta printers rather than MZV or ZV, and should be
+    considered for the use. If the resonance frequency is sufficiently
+    large (more than 50-60 Hz), then one can even attempt to test 2HUMP_EI
+    shaper (by running the suggested test above with `SET_INPUT_SHAPER
+    SHAPER_TYPE=2HUMP_EI`), but check the considerations in the [section
+    below](#selecting-max_accel) before enabling it.
 
 ### Selecting max_accel
 
@@ -239,22 +249,25 @@ a good idea to check that too.
 Choose the minimum out of the two acceleration values (from ringing and
 smoothing), and put it as `max_accel` into printer.cfg.
 
+!!! note "Note: Smoothing with EI and MZV shappers"
+    It may happen - especially at low ringing frequencies - that EI shaper
+    will cause too much smoothing even at lower accelerations. In this
+    case, MZV may be a better choice, because it may allow higher
+    acceleration values.
 
-As a note, it may happen - especially at low ringing frequencies - that EI
-shaper will cause too much smoothing even at lower accelerations. In this case,
-MZV may be a better choice, because it may allow higher acceleration values.
+    At very low ringing frequencies (~25 Hz and below) even MZV shaper may create
+    too much smoothing. If that is the case, you can also try to repeat the
+    steps in [Choosing input shaper](#choosing-input-shaper) section with ZV shaper,
+    by using `SET_INPUT_SHAPER SHAPER_TYPE=ZV` command instead. ZV shaper should
+    show even less smoothing than MZV, but is more sensitive to errors in measuring
+    the ringing frequencies.
 
-At very low ringing frequencies (~25 Hz and below) even MZV shaper may create
-too much smoothing. If that is the case, you can also try to repeat the
-steps in [Choosing input shaper](#choosing-input-shaper) section with ZV shaper,
-by using `SET_INPUT_SHAPER SHAPER_TYPE=ZV` command instead. ZV shaper should
-show even less smoothing than MZV, but is more sensitive to errors in measuring
-the ringing frequencies.
-
-Another consideration is that if a resonance frequency is too low (below 20-25
-Hz), it might be a good idea to increase the printer stiffness or reduce the
-moving mass. Otherwise, acceleration and printing speed may be limited due too
-much smoothing now instead of ringing.
+!!! tip "Tip: Mechanical optimizations"
+    Another consideration is that if a resonance frequency is too low
+    (below 20-25 Hz), it might be a good idea to increase the printer
+    stiffness or reduce the moving mass. Otherwise, acceleration and
+    printing speed may be limited due too much smoothing now instead of
+    ringing.
 
 
 ### Fine-tuning resonance frequencies
@@ -295,12 +308,14 @@ Repeat these steps for the Y axis in the same manner, replacing references to X
 axis with the axis Y (e.g. replace `shaper_freq_x` with `shaper_freq_y` in
 the formulae and in the `TUNING_TOWER` command).
 
-As an example, let's assume you have had measured the ringing frequency for one
-of the axis equal to 45 Hz. This gives start = 45 * 83 / 132 = 28.30
-and factor = 45 / 66 = 0.6818 values for `TUNING_TOWER` command.
-Now let's assume that after printing the test model, the fourth band from the
-bottom gives the least ringing. This gives the updated shaper_freq_? value
-equal to 45 * (39 + 5 * 4) / 66 ≈ 40.23.
+
+!!! example
+    Let's assume you have had measured the ringing frequency for one of the
+    axis equal to 45 Hz. This gives start = 45 * 83 / 132 = 28.30 and
+    factor = 45 / 66 = 0.6818 values for `TUNING_TOWER` command. Now let's
+    assume that after printing the test model, the fourth band from the
+    bottom gives the least ringing. This gives the updated shaper_freq_?
+    value equal to 45 * (39 + 5 * 4) / 66 ≈ 40.23.
 
 After both new `shaper_freq_x` and `shaper_freq_y` parameters have been
 calculated, you can update `[input_shaper]` section in `printer.cfg` with the

--- a/docs/Rotation_Distance.md
+++ b/docs/Rotation_Distance.md
@@ -79,11 +79,13 @@ If the actual_extrude_distance differs from requested_extrude_distance
 by more than about 2mm then it is a good idea to perform the steps
 above a second time.
 
-Note: Do *not* use a "measure and trim" type of method to calibrate x,
-y, or z type axes. The "measure and trim" method is not accurate
-enough for those axes and will likely lead to a worse configuration.
-Instead, if needed, those axes can be determined by
-[measuring the belts, pulleys, and lead screw hardware](#obtaining-rotation_distance-by-inspecting-the-hardware).
+!!! important
+    Do *not* use a "measure and trim" type of method to calibrate x, y, or
+    z type axes. The "measure and trim" method is not accurate enough for
+    those axes and will likely lead to a worse configuration. Instead, if
+    needed, those axes can be determined by [measuring the belts, pulleys,
+    and lead screw
+    hardware](#obtaining-rotation_distance-by-inspecting-the-hardware).
 
 ## Obtaining rotation_distance by inspecting the hardware
 
@@ -162,13 +164,14 @@ with 80 teeth then one would use `gear_ratio: 80:16`. Indeed, one
 could open a common off the shelf "gear box" and count the teeth in it
 to confirm its gear ratio.
 
-Note that sometimes a gearbox will have a slightly different gear
-ratio than what it is advertised as. The common BMG extruder motor
-gears are an example of this - they are advertised as "3:1" but
-actually use "50:17" gearing. (Using teeth numbers without a common
-denominator may improve overall gear wear as the teeth don't always
-mesh the same way with each revolution.) The common "5.18:1 planetary
-gearbox", is more accurately configured with `gear_ratio: 57:11`.
+!!! note
+    Sometimes a gearbox will have a slightly different gear ratio than what
+    it is advertised as. The common BMG extruder motor gears are an example
+    of this - they are advertised as "3:1" but actually use "50:17"
+    gearing. (Using teeth numbers without a common denominator may improve
+    overall gear wear as the teeth don't always mesh the same way with each
+    revolution.) The common "5.18:1 planetary gearbox", is more accurately
+    configured with `gear_ratio: 57:11`.
 
 If several gears are used on an axis then it is possible to provide a
 comma separated list to gear_ratio. For example, a "5:1" gear box

--- a/docs/SDCard_Updates.md
+++ b/docs/SDCard_Updates.md
@@ -74,9 +74,11 @@ the default location it can be done by specifying the `-f` option:
 ./scripts/flash-sdcard.sh -f ~/downloads/klipper.bin /dev/ttyAMA0 btt-skr-v1.3
 ```
 
-Note that when upgrading a MKS Robin E3 it is not necessary to manually run
-`update_mks_robin.py` and supply the resulting binary to `flash-sdcard.sh`.
-This procedure is automated during the upload process.
+!!! tip: "Tip: MKS Robin E3 updates'
+    Note that when upgrading a MKS Robin E3 it is not necessary to manually
+    run `update_mks_robin.py` and supply the resulting binary to
+    `flash-sdcard.sh`. This procedure is automated during the upload
+    process.
 
 ## Caveats
 

--- a/docs/TMC_Drivers.md
+++ b/docs/TMC_Drivers.md
@@ -338,9 +338,10 @@ is small (eg, less than 5) then it may result in unstable homing. A
 faster homing speed may increase the range and make the operation more
 stable.
 
-Note that if any change is made to driver current, homing speed, or a
-notable change is made to the printer hardware, then it will be
-necessary to run the tuning process again.
+!!! important
+    If any change is made to driver current, homing speed, or a notable
+    change is made to the printer hardware, then it will be necessary to
+    run the tuning process again.
 
 #### Using Macros when Homing
 
@@ -383,8 +384,9 @@ The resulting macro can be called from a
 [homing_override config section](Config_Reference.md#homing_override)
 or from a [START_PRINT macro](Slicers.md#klipper-gcode_macro).
 
-Note that if the driver current during homing is changed, then the
-tuning process should be run again.
+!!! important
+    If the driver current during homing is changed, then the tuning process
+    should be run again.
 
 ### Tips for sensorless homing on CoreXY
 
@@ -435,14 +437,14 @@ Each of these fields is defined in the Trinamic datasheet for each
 driver. These datasheets can be found on the
 [Trinamic website](https://www.trinamic.com/).
 
-Note that the Trinamic datasheets sometime use wording that can
-confuse a high-level setting (such as "hysteresis end") with a
-low-level field value (eg, "HEND"). In Klipper, `driver_XXX` and
-SET_TMC_FIELD always set the low-level field value that is actually
-written to the driver. So, for example, if the Trinamic datasheet
-states that a value of 3 must be written to the HEND field to obtain a
-"hysteresis end" of 0, then set `driver_HEND=3` to obtain the
-high-level value of 0.
+!!!note
+    The Trinamic datasheets sometime use wording that can confuse a
+    high-level setting (such as "hysteresis end") with a low-level field
+    value (eg, "HEND"). In Klipper, `driver_XXX` and SET_TMC_FIELD always
+    set the low-level field value that is actually written to the driver.
+    So, for example, if the Trinamic datasheet states that a value of 3
+    must be written to the HEND field to obtain a "hysteresis end" of 0,
+    then set `driver_HEND=3` to obtain the high-level value of 0.
 
 ## Common Questions
 
@@ -488,17 +490,17 @@ Otherwise, this error is typically the result of incorrect SPI wiring,
 an incorrect Klipper configuration of the SPI settings, or an
 incomplete configuration of devices on an SPI bus.
 
-Note that if the driver is on a shared SPI bus with multiple devices
-then be sure to fully configure every device on that shared SPI bus in
-Klipper. If a device on a shared SPI bus is not configured, then it
-may incorrectly respond to commands not intended for it and corrupt
-the communication to the intended device. If there is a device on a
-shared SPI bus that can not be configured in Klipper, then use a
-[static_digital_output config section](Config_Reference.md#static_digital_output)
-to set the CS pin of the unused device high (so that it will not
-attempt to use the SPI bus). The board's schematic is often a useful
-reference for finding which devices are on an SPI bus and their
-associated pins.
+!!! important "Important: Shared SPI bus"
+    If the driver is on a shared SPI bus with multiple devices then be sure
+    to fully configure every device on that shared SPI bus in Klipper. If a
+    device on a shared SPI bus is not configured, then it may incorrectly
+    respond to commands not intended for it and corrupt the communication
+    to the intended device. If there is a device on a shared SPI bus that
+    can not be configured in Klipper, then use a [static_digital_output
+    config section](Config_Reference.md#static_digital_output) to set the
+    CS pin of the unused device high (so that it will not attempt to use
+    the SPI bus). The board's schematic is often a useful reference for
+    finding which devices are on an SPI bus and their associated pins.
 
 ### Why did I get a "TMC reports error: ..." error?
 

--- a/docs/TSL1401CL_Filament_Width_Sensor.md
+++ b/docs/TSL1401CL_Filament_Width_Sensor.md
@@ -15,8 +15,8 @@ Sensor generates analog output based on calculated filament width. Output
 voltage always equals to detected filament width (Ex. 1.65v, 1.70v, 3.0v).
 Host module monitors voltage changes and adjusts extrusion multiplier.
 
-## Note:
-
-Sensor readings done with 10 mm intervals by default. If necessary you are
-free to change this setting by editing ***MEASUREMENT_INTERVAL_MM*** parameter
-in **filament_width_sensor.py** file.
+!!! note
+    Sensor readings done with 10 mm intervals by default. If necessary you
+    are free to change this setting by editing
+    ***MEASUREMENT_INTERVAL_MM*** parameter in **filament_width_sensor.py**
+    file.

--- a/docs/Using_PWM_Tools.md
+++ b/docs/Using_PWM_Tools.md
@@ -14,15 +14,15 @@ commands, which stand for _spindle speed CW_ (`M3 S[0-255]`),
 _spindle speed CCW_ (`M4 S[0-255]`) and _spindle stop_ (`M5`).
 
 
-**Warning:** When driving a laser, keep all security precautions
-that you can think of! Diode lasers are usually inverted.
-This means, that when the MCU restarts, the laser will be
-_fully on_ for the time it takes the MCU to start up again.
-For good measure, it is recommended to _always_ wear appropriate
-laser-goggles of the right wavelength if the laser is powered;
-and to disconnect the laser when it is not needed.
-Also, you should configure a safety timeout,
-so that when your host or MCU encounters an error, the tool will stop.
+!!! danger
+    When driving a laser, keep all security precautions that you can think
+    of! Diode lasers are usually inverted. This means, that when the MCU
+    restarts, the laser will be _fully on_ for the time it takes the MCU to
+    start up again. For good measure, it is recommended to _always_ wear
+    appropriate laser-goggles of the right wavelength if the laser is
+    powered; and to disconnect the laser when it is not needed. Also, you
+    should configure a safety timeout, so that when your host or MCU
+    encounters an error, the tool will stop.
 
 For an example configuration, see [config/sample-pwm-tool.cfg](/config/sample-pwm-tool.cfg).
 

--- a/docs/_klipper3d/css/extra.css
+++ b/docs/_klipper3d/css/extra.css
@@ -24,3 +24,23 @@ img {
     margin: 0 auto;
     display: block;
 }
+
+.md-typeset :is(.admonition, details) {
+    font-size: 0.7rem;
+}
+
+.md-typeset :is(.admonition, details):is(.warning, .caution, .attention, .important, .danger, .error) {
+    font-size: 0.748rem; /* sqrt(0.7/0.8)*0.8 */
+}
+
+.md-typeset :is(.admonition, details):is(.important) {
+    border-color: #ff9100;
+}
+
+.md-typeset :is(.important)> :is(.admonition-title, summary)::before {
+    background-color: #ff9100;
+}
+
+.md-typeset :is(.important)> :is(.admonition-title, summary) {
+    background-color: rgba(255, 145, 0, .1);
+}

--- a/docs/_klipper3d/mkdocs-requirements.txt
+++ b/docs/_klipper3d/mkdocs-requirements.txt
@@ -1,10 +1,10 @@
 # Python virtualenv module requirements for mkdocs
-jinja2==3.0.3
-mkdocs==1.2.3
-mkdocs-material==8.1.3
-mkdocs-simple-hooks==0.1.3
+jinja2==3.1.2
+mkdocs==1.3.1
+mkdocs-material==8.4.1
+mkdocs-simple-hooks==0.1.5
 mkdocs-exclude==1.0.2
-mdx-truly-sane-lists==1.2
+mdx-truly-sane-lists==1.3
 mdx-breakless-lists==1.0.1
 py-gfm==1.0.2
 markdown==3.3.7

--- a/docs/_klipper3d/mkdocs.yml
+++ b/docs/_klipper3d/mkdocs.yml
@@ -21,6 +21,9 @@ markdown_extensions:
   - mdx_partial_gfm
   - mdx_truly_sane_lists
   - mdx_breakless_lists
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
 plugins:
   search:
     lang: en

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,13 +6,20 @@ title: Welcome
 
 ![](img/klipper-logo.png){ .center-image }
 
-Klipper is a 3d-Printer firmware. It combines the power of a general
+Danger-Klipper is a 3d-Printer firmware. It combines the power of a general
 purpose computer with one or more micro-controllers. See the
 [features](Features.md) document for more information on why you
 should use Klipper.
 
-To begin using Klipper start by [installing](Installation.md) it.
+!!! danger
+    This is a fork of [Klipper](https://www.klipper3d.org/), with the goal
+    of supporting features and behavior that could be "risky" if used
+    incorrectly. If you are not an experienced Klipper user, it is
+    recommended that you familiarize yourself with the original Klipper
+    project first.
 
-Klipper is Free Software. Read the [documentation](Overview.md) or
-view [the Klipper code on github](https://github.com/DangerKlippers/danger-klipper).
+To begin using Danger-Klipper start by [installing](Installation.md) it.
+
+Danger-Klipper is Free Software. Read the [documentation](Overview.md) or
+view [the Danger-Klipper code on github](https://github.com/DangerKlippers/danger-klipper).
 We depend on the generous support from our [sponsors](Sponsors.md).


### PR DESCRIPTION

Proposal for distinguishing Danger specific features:
 - Add a compatibility warning at the top of  "Configuration reference" and "G-Codes / Additional Commands",
 - Prefix gcode and config sections that are only present in Danger-Klipper fork with a :warning: symbol,
 - On index.md, add a ':zap: Danger' admonition stating that this is a "risky" fork and sending beginners back to mainline Klipper.

Also in this PR:
 - Update mkdocs python dependencies,
 - Update `.gitingore` for ignoring the `/site/` output directory, and few other tweaks,
 - Replace some documentation paragraphs with admonitions. This is mainly an experiment to see if it can improve the flow. I admit that I may have gone too far with this. Tell me what you think.

Howto preview the documentation:
```bash
<enable your python virtual environment>
cd klipper/docs/_klipper3d/
pip install -r mkdocs-requirements.txt
mkdocs serve
```