### PR TITLE
Add ability to modify PID parameters without a reload

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -863,6 +863,11 @@ WRITE_FILE parameter is enabled, then the file /tmp/heattest.txt will
 be created with a log of all temperature samples taken during the
 test.
 
+#### SET_HEATER_PID
+`SET_HEATER_PID HEATER=<config_name> KP=<kp> KI=<ki> KD=<kd>`: Will
+allow one to manually change PID parameters of heaters without a 
+reload of the firmware.
+
 ### [pause_resume]
 
 The following commands are available when the

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -77,7 +77,7 @@ class Heater:
         gcode.register_mux_command(
             "SET_HEATER_PID",
             "HEATER",
-            self.name, 
+            self.name,
             self.cmd_SET_HEATER_PID,
             desc=self.cmd_SET_HEATER_PID_help,
         )
@@ -192,13 +192,13 @@ class Heater:
     def cmd_SET_HEATER_PID(self, gcmd):
         if not isinstance(self.control, ControlPID):
             raise gcmd.error("Not a PID controlled heater")
-        kp = gcmd.get_float('KP', None)
+        kp = gcmd.get_float("KP", None)
         if kp is not None:
             self.control.Kp = kp / PID_PARAM_BASE
-        ki = gcmd.get_float('KI', None)
+        ki = gcmd.get_float("KI", None)
         if ki is not None:
             self.control.Ki = ki / PID_PARAM_BASE
-        kd = gcmd.get_float('KD', None)
+        kd = gcmd.get_float("KD", None)
         if kd is not None:
             self.control.Kd = kd / PID_PARAM_BASE
 

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -74,6 +74,13 @@ class Heater:
             self.cmd_SET_HEATER_TEMPERATURE,
             desc=self.cmd_SET_HEATER_TEMPERATURE_help,
         )
+        gcode.register_mux_command(
+            "SET_HEATER_PID",
+            "HEATER",
+            self.name, 
+            self.cmd_SET_HEATER_PID,
+            desc=self.cmd_SET_HEATER_PID_help,
+        )
 
     def set_pwm(self, read_time, value):
         if self.target_temp <= 0.0:
@@ -179,6 +186,21 @@ class Heater:
         temp = gcmd.get_float("TARGET", 0.0)
         pheaters = self.printer.lookup_object("heaters")
         pheaters.set_temperature(self, temp)
+
+    cmd_SET_HEATER_PID_help = "Sets a heater PID parameter"
+
+    def cmd_SET_HEATER_PID(self, gcmd):
+        if not isinstance(self.control, ControlPID):
+            raise gcmd.error("Not a PID controlled heater")
+        kp = gcmd.get_float('KP', None)
+        if kp is not None:
+            self.control.Kp = kp / PID_PARAM_BASE
+        ki = gcmd.get_float('KI', None)
+        if ki is not None:
+            self.control.Ki = ki / PID_PARAM_BASE
+        kd = gcmd.get_float('KD', None)
+        if kd is not None:
+            self.control.Kd = kd / PID_PARAM_BASE
 
 
 ######################################################################


### PR DESCRIPTION
Upstreamed a patch we have internally that allows you to modify your PID parameters without reloading your config. This is useful to work around the current PID implementation in klipper when manually tuning. 