### PR TITLE
revert markupsafe version

### DIFF
--- a/scripts/klippy-requirements.txt
+++ b/scripts/klippy-requirements.txt
@@ -7,5 +7,5 @@ pyserial==3.4
 greenlet==2.0.2
 Jinja2==2.11.3
 python-can==3.3.4
-markupsafe==2.1.3
+markupsafe==1.1.1 # https://github.com/Klipper3d/klipper/pull/5286
 numpy==1.25.2


### PR DESCRIPTION
I had `jinja2>3` installed so I didn't catch the issue.. `jinja2<3` requires `markupsafe==1.1.1`