### PR TITLE
temperature_mcu: add reference_voltage

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Features merged into the master branch:
 
 - [danger_options: expose the multi mcu homing timeout as a parameter](https://github.com/DangerKlippers/danger-klipper/pull/93)
 
+- [temperature_mcu: add reference_voltage](https://github.com/DangerKlippers/danger-klipper/pull/99) ([klipper#5713](https://github.com/Klipper3d/klipper/pull/5713))
+
 If you're feeling adventurous, take a peek at the extra features in the bleeding-edge branch:
 
   - [dmbutyugin's advanced-features branch](https://github.com/DangerKlippers/danger-klipper/pull/69) [dmbutyugin/advanced-features](https://github.com/dmbutyugin/klipper/commits/advanced-features)

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2814,6 +2814,8 @@ monitor these temperatures.
 sensor_type: temperature_mcu
 #sensor_mcu: mcu
 #   The micro-controller to read from. The default is "mcu".
+#reference_voltage:
+#   The reference voltage for the ADC of the mcu. Default is 3.3
 #sensor_temperature1:
 #sensor_adc1:
 #   Specify the above two parameters (a temperature in Celsius and an


### PR DESCRIPTION
This allows for boards that don't run their ADC with 3.3V to output accurate MCU temperature readings.

This was originally posted in https://github.com/Klipper3d/klipper/pull/5713 but was rejected by mainline.

The code was written by iKirin of Annex Engineering. With his permission, I've cleaned it up a bit, added a few missing cases and formatted it with Black.

The use case for this is especially rp2040 boards with accurate ADC references. Because of how the Pico board is set up, getting a stable reference is only possible by pulling the reference down to 3.0V. Without this patch, a 3.3V reference is assumed.