### PR TITLE
Sensorless dwell bug

### DIFF
--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -266,8 +266,7 @@ class Homing:
                     if dwell_time is None:
                         dwell_time = ch.current_change_dwell_time
                     ch.set_current_for_homing(print_time)
-            if dwell_time:
-                self.toolhead.dwell(dwell_time)
+            self.toolhead.dwell(dwell_time)
 
     def _set_current_post_homing(self, homing_axes):
         print_time = self.toolhead.get_last_move_time()
@@ -281,12 +280,12 @@ class Homing:
             chs = rail.get_tmc_current_helpers()
             dwell_time = None
             for ch in chs:
+                print("current helping")
                 if ch is not None and ch.needs_home_current_change():
                     if dwell_time is None:
                         dwell_time = ch.current_change_dwell_time
                     ch.set_current_for_normal(print_time)
-            if dwell_time:
-                self.toolhead.dwell(dwell_time)
+            self.toolhead.dwell(dwell_time)
 
     def home_rails(self, rails, forcepos, movepos):
         # Notify of upcoming homing operation

--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -266,7 +266,8 @@ class Homing:
                     if dwell_time is None:
                         dwell_time = ch.current_change_dwell_time
                     ch.set_current_for_homing(print_time)
-            self.toolhead.dwell(dwell_time)
+            if dwell_time:
+                self.toolhead.dwell(dwell_time)
 
     def _set_current_post_homing(self, homing_axes):
         print_time = self.toolhead.get_last_move_time()
@@ -280,12 +281,12 @@ class Homing:
             chs = rail.get_tmc_current_helpers()
             dwell_time = None
             for ch in chs:
-                print("current helping")
                 if ch is not None and ch.needs_home_current_change():
                     if dwell_time is None:
                         dwell_time = ch.current_change_dwell_time
                     ch.set_current_for_normal(print_time)
-            self.toolhead.dwell(dwell_time)
+            if dwell_time:
+                self.toolhead.dwell(dwell_time)
 
     def home_rails(self, rails, forcepos, movepos):
         # Notify of upcoming homing operation

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -400,9 +400,7 @@ class PrinterRail:
         self.endstop_map = {}
         self.add_extra_stepper(config)
         mcu_stepper = self.steppers[0]
-        self._tmc_current_helpers = [
-            s.get_tmc_current_helper() for s in self.steppers
-        ]
+        self._tmc_current_helpers = None
         self.get_name = mcu_stepper.get_name
         self.get_commanded_position = mcu_stepper.get_commanded_position
         self.calc_position_from_coord = mcu_stepper.calc_position_from_coord
@@ -485,6 +483,10 @@ class PrinterRail:
             )
 
     def get_tmc_current_helpers(self):
+        if self._tmc_current_helpers is None:
+            self._tmc_current_helpers = [
+                s.get_tmc_current_helper() for s in self.steppers
+            ]
         return self._tmc_current_helpers
 
     def get_range(self):


### PR DESCRIPTION
current helpers was being initialized at stepper init, and at that point all the current helpers haven't been inited yet. delay the assignment of current helper list