### PR TITLE
per_move_pressure_advance extruder flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ If I want my printer to light itself on fire, I should be able to make my printe
 
 - [adxl345: improve ACCELEROMETER_QUERY command](https://github.com/DangerKlippers/danger-klipper/pull/124)
 
+- [extruder: add flag to use the PA constant from a trapq move vs a cached value](https://github.com/DangerKlippers/danger-klipper/pull/132)
 If you're feeling adventurous, take a peek at the extra features in the bleeding-edge branch:
 
 - [dmbutyugin's advanced-features branch](https://github.com/DangerKlippers/danger-klipper/pull/69) [dmbutyugin/advanced-features](https://github.com/dmbutyugin/klipper/commits/advanced-features)

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -987,6 +987,11 @@ max_temp:
 #   heater and sensor hardware failures. Set this range just wide
 #   enough so that reasonable temperatures do not result in an error.
 #   These parameters must be provided.
+per_move_pressure_advance: False
+#   If true, uses pressure advance constant from trapq when processing moves
+#   This causes changes to pressure advance be taken into account immediately,
+#   for all moves in the current queue, rather than ~250ms later once the queue gets flushed
+
 ```
 
 ### [heater_bed]

--- a/klippy/chelper/kin_extruder.c
+++ b/klippy/chelper/kin_extruder.c
@@ -59,10 +59,20 @@ pa_move_integrate(struct move *m, double pressure_advance
         start = 0.;
     if (end > m->move_t)
         end = m->move_t;
+    // figure out what to use for pressure advance
+    // use_pa_from_trapq is passed in via the move's axes_r.z field
+    // if this is True (not 0), we use the pressure advance value in the axes_r.y
+    // otherwise, we use the one passed in as an arg to this function (the stored one)
+    int use_pa_from_trapq = m->axes_r.z != 0.;
+    if (use_pa_from_trapq) {
+        pressure_advance = m->axes_r.y;
+    }
+    else {
+        int can_pressure_advance = m->axes_r.y != 0.;
+        if (!can_pressure_advance)
+            pressure_advance = 0.;
+    }
     // Calculate base position and velocity with pressure advance
-    int can_pressure_advance = m->axes_r.y != 0.;
-    if (!can_pressure_advance)
-        pressure_advance = 0.;
     base += pressure_advance * m->start_v;
     double start_v = m->start_v + pressure_advance * 2. * m->half_accel;
     // Calculate definitive integral

--- a/klippy/extras/danger_options.py
+++ b/klippy/extras/danger_options.py
@@ -23,6 +23,7 @@ class DangerOptions:
             "homing_elapsed_distance_tolerance", 0.5, minval=0.0
         )
         self.adc_ignore_limits = config.getboolean("adc_ignore_limits", False)
+        self.store_pa_in_trapq = config.getboolean("store_pa_in_trapq", False)
 
 
 def load_config(config):

--- a/klippy/extras/danger_options.py
+++ b/klippy/extras/danger_options.py
@@ -23,7 +23,6 @@ class DangerOptions:
             "homing_elapsed_distance_tolerance", 0.5, minval=0.0
         )
         self.adc_ignore_limits = config.getboolean("adc_ignore_limits", False)
-        self.store_pa_in_trapq = config.getboolean("store_pa_in_trapq", False)
 
 
 def load_config(config):

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -216,7 +216,6 @@ class ExtruderStepper:
 class PrinterExtruder:
     def __init__(self, config, extruder_num):
         self.printer = config.get_printer()
-        self.danger_options = self.printer.lookup_object("danger_options")
         self.name = config.get_name()
         self.last_position = 0.0
         # Setup hotend heater
@@ -264,6 +263,11 @@ class PrinterExtruder:
         self.trapq = ffi_main.gc(ffi_lib.trapq_alloc(), ffi_lib.trapq_free)
         self.trapq_append = ffi_lib.trapq_append
         self.trapq_finalize_moves = ffi_lib.trapq_finalize_moves
+
+        self.per_move_pressure_advance = config.getboolean(
+            "per_move_pressure_advance", False
+        )
+
         # Setup extruder stepper
         self.extruder_stepper = None
         if (
@@ -361,9 +365,7 @@ class PrinterExtruder:
         pressure_advance = 0.0
         if axis_r > 0.0 and (move.axes_d[0] or move.axes_d[1]):
             pressure_advance = self.extruder_stepper.pressure_advance
-        use_pa_from_trapq = (
-            1.0 if self.danger_options.store_pa_in_trapq else 0.0
-        )
+        use_pa_from_trapq = 1.0 if self.per_move_pressure_advance else 0.0
         # Queue movement (x is extruder movement, y is pressure advance flag)
         self.trapq_append(
             self.trapq,

--- a/test/klippy/extruders.cfg
+++ b/test/klippy/extruders.cfg
@@ -48,6 +48,7 @@ pid_Ki: 1.08
 pid_Kd: 114
 min_temp: 0
 max_temp: 210
+per_move_pressure_advance: True
 
 [extruder_stepper my_extra_stepper]
 extruder: extruder


### PR DESCRIPTION
basically a flag to revert https://github.com/Klipper3d/klipper/commit/29724a7411063879d3343a0610b4f288e045cabf and allow pressure advance to come through trapq

should resolve https://github.com/Klipper3d/klipper/issues/6338


in theory, the change in https://github.com/Klipper3d/klipper/commit/29724a7411063879d3343a0610b4f288e045cabf can introduce about 250ms of lag after changing pressure advance, which can reduce performance when printing very fast and frequently changing pressure advance while printing (ie variable pressure advance in role-based gcode)


to enable, add to [extruder]:


`per_move_pressure_advance: True`