### PR TITLE
load force move and enable it by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ If I want my printer to light itself on fire, I should be able to make my printe
 - [adxl345: improve ACCELEROMETER_QUERY command](https://github.com/DangerKlippers/danger-klipper/pull/124)
 
 - [extruder: add flag to use the PA constant from a trapq move vs a cached value](https://github.com/DangerKlippers/danger-klipper/pull/132)
+
+- [force_move: turn on by default](https://github.com/DangerKlippers/danger-klipper/pull/135)
+
 If you're feeling adventurous, take a peek at the extra features in the bleeding-edge branch:
 
 - [dmbutyugin's advanced-features branch](https://github.com/DangerKlippers/danger-klipper/pull/69) [dmbutyugin/advanced-features](https://github.com/dmbutyugin/klipper/commits/advanced-features)

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1684,7 +1684,9 @@ file for a Marlin compatible M808 G-Code macro.
 [sdcard_loop]
 ```
 
-### [force_move]
+### ⚠ [force_move]
+
+This module is enabled by default in DangerKlipper!
 
 Support manually moving stepper motors for diagnostic purposes. Note,
 using this feature may place the printer in an invalid state - see the
@@ -1692,9 +1694,9 @@ using this feature may place the printer in an invalid state - see the
 
 ```
 [force_move]
-#enable_force_move: False
+#enable_force_move: True
 #   Set to true to enable FORCE_MOVE and SET_KINEMATIC_POSITION
-#   extended G-Code commands. The default is false.
+#   extended G-Code commands. The default is true.
 ```
 
 ### [pause_resume]

--- a/klippy/extras/force_move.py
+++ b/klippy/extras/force_move.py
@@ -49,7 +49,7 @@ class ForceMove:
             self.cmd_STEPPER_BUZZ,
             desc=self.cmd_STEPPER_BUZZ_help,
         )
-        if config.getboolean("enable_force_move", False):
+        if config.getboolean("enable_force_move", True):
             gcode.register_command(
                 "FORCE_MOVE", self.cmd_FORCE_MOVE, desc=self.cmd_FORCE_MOVE_help
             )

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -198,6 +198,9 @@ class Printer:
             m.add_printer_objects(config)
         for section_config in config.get_prefix_sections(""):
             self.load_object(config, section_config.get_name(), None)
+        # dangerklipper on-by-default extras
+        for section_config in ["force_move"]:
+            self.load_object(config, section_config, None)
         for m in [toolhead]:
             m.add_printer_objects(config)
         # Validate that there are no undefined parameters in the config file


### PR DESCRIPTION
adding [force_move] every time you start a config is annoying and there's very little downside to having it on.

let's just load it no matter what (and default it to on)