### PR TITLE
move add_config_cmd calls to config callback across all extras

### DIFF
--- a/klippy/extras/adxl345.py
+++ b/klippy/extras/adxl345.py
@@ -37,6 +37,7 @@ Accel_Measurement = collections.namedtuple(
     "Accel_Measurement", ("time", "accel_x", "accel_y", "accel_z")
 )
 
+
 # Helper class to obtain measurements
 class AccelQueryHelper:
     def __init__(self, printer, cconn):
@@ -283,6 +284,7 @@ MIN_MSG_TIME = 0.100
 BYTES_PER_SAMPLE = 5
 SAMPLES_PER_BLOCK = 10
 
+
 # Printer class that controls ADXL345 chip
 class ADXL345:
     def __init__(self, config):
@@ -313,13 +315,7 @@ class ADXL345:
         self.oid = oid = mcu.create_oid()
         self.query_adxl345_cmd = self.query_adxl345_end_cmd = None
         self.query_adxl345_status_cmd = None
-        mcu.add_config_cmd(
-            "config_adxl345 oid=%d spi_oid=%d" % (oid, self.spi.get_oid())
-        )
-        mcu.add_config_cmd(
-            "query_adxl345 oid=%d clock=0 rest_ticks=0" % (oid,),
-            on_restart=True,
-        )
+
         mcu.register_config_callback(self._build_config)
         mcu.register_response(self._handle_adxl345_data, "adxl345_data", oid)
         # Clock tracking
@@ -340,6 +336,13 @@ class ADXL345:
         )
 
     def _build_config(self):
+        self.mcu.add_config_cmd(
+            "config_adxl345 oid=%d spi_oid=%d" % (self.oid, self.spi.get_oid())
+        )
+        self.mcu.add_config_cmd(
+            "query_adxl345 oid=%d clock=0 rest_ticks=0" % (self.oid,),
+            on_restart=True,
+        )
         cmdqueue = self.spi.get_command_queue()
         self.query_adxl345_cmd = self.mcu.lookup_command(
             "query_adxl345 oid=%c clock=%u rest_ticks=%u", cq=cmdqueue

--- a/klippy/extras/angle.py
+++ b/klippy/extras/angle.py
@@ -500,6 +500,7 @@ class Angle:
         }
         sensor_type = config.getchoice("sensor_type", {s: s for s in sensors})
         sensor_class = sensors[sensor_type]
+        self.sensor_type = sensor_type
         self.spi = bus.MCU_SPI_from_config(
             config, sensor_class.SPI_MODE, default_speed=sensor_class.SPI_SPEED
         )
@@ -508,14 +509,7 @@ class Angle:
         self.sensor_helper = sensor_class(config, self.spi, oid)
         # Setup mcu sensor_spi_angle bulk query code
         self.query_spi_angle_cmd = self.query_spi_angle_end_cmd = None
-        mcu.add_config_cmd(
-            "config_spi_angle oid=%d spi_oid=%d spi_angle_type=%s"
-            % (oid, self.spi.get_oid(), sensor_type)
-        )
-        mcu.add_config_cmd(
-            "query_spi_angle oid=%d clock=0 rest_ticks=0 time_shift=0" % (oid,),
-            on_restart=True,
-        )
+
         mcu.register_config_callback(self._build_config)
         mcu.register_response(
             self._handle_spi_angle_data, "spi_angle_data", oid
@@ -531,6 +525,16 @@ class Angle:
         )
 
     def _build_config(self):
+        self.mcu.add_config_cmd(
+            "config_spi_angle oid=%d spi_oid=%d spi_angle_type=%s"
+            % (self.oid, self.spi.get_oid(), self.sensor_type)
+        )
+        self.mcu.add_config_cmd(
+            "query_spi_angle oid=%d clock=0 rest_ticks=0 time_shift=0"
+            % (self.oid,),
+            on_restart=True,
+        )
+
         freq = self.mcu.seconds_to_clock(1.0)
         while float(TCODE_ERROR << self.time_shift) / freq < 0.002:
             self.time_shift += 1

--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -63,7 +63,7 @@ class MCU_SPI:
                 "spi_set_bus oid=%d spi_bus=%%s mode=%d rate=%d"
                 % (self.oid, mode, speed)
             )
-        self.cmd_queue = mcu.alloc_command_queue()
+
         mcu.register_config_callback(self.build_config)
         self.spi_send_cmd = self.spi_transfer_cmd = None
 
@@ -84,6 +84,7 @@ class MCU_SPI:
         return self.cmd_queue
 
     def build_config(self):
+        self.cmd_queue = self.mcu.alloc_command_queue()
         if self.pin is None:
             self.mcu.add_config_cmd(
                 "config_spi_without_cs oid=%d" % (self.oid,)

--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -38,6 +38,7 @@ def resolve_bus_name(mcu, param, bus):
 # SPI
 ######################################################################
 
+
 # Helper code for working with devices connected to an MCU via an SPI bus
 class MCU_SPI:
     def __init__(
@@ -45,15 +46,11 @@ class MCU_SPI:
     ):
         self.mcu = mcu
         self.bus = bus
+        self.pin = pin
+        self.cs_active_high = cs_active_high
         # Config SPI object (set all CS pins high before spi_set_bus commands)
         self.oid = mcu.create_oid()
-        if pin is None:
-            mcu.add_config_cmd("config_spi_without_cs oid=%d" % (self.oid,))
-        else:
-            mcu.add_config_cmd(
-                "config_spi oid=%d pin=%s cs_active_high=%d"
-                % (self.oid, pin, cs_active_high)
-            )
+
         # Generate SPI bus config message
         if sw_pins is not None:
             self.config_fmt = (
@@ -87,6 +84,15 @@ class MCU_SPI:
         return self.cmd_queue
 
     def build_config(self):
+        if self.pin is None:
+            self.mcu.add_config_cmd(
+                "config_spi_without_cs oid=%d" % (self.oid,)
+            )
+        else:
+            self.mcu.add_config_cmd(
+                "config_spi oid=%d pin=%s cs_active_high=%d"
+                % (self.oid, self.pin, self.cs_active_high)
+            )
         if "%" in self.config_fmt:
             bus = resolve_bus_name(self.mcu, "spi_bus", self.bus)
             self.config_fmt = self.config_fmt % (bus,)
@@ -176,6 +182,7 @@ def MCU_SPI_from_config(
 # I2C
 ######################################################################
 
+
 # Helper code for working with devices connected to an MCU via an I2C bus
 class MCU_I2C:
     def __init__(self, mcu, bus, addr, speed, sw_pins=None):
@@ -183,7 +190,7 @@ class MCU_I2C:
         self.bus = bus
         self.i2c_address = addr
         self.oid = self.mcu.create_oid()
-        mcu.add_config_cmd("config_i2c oid=%d" % (self.oid,))
+
         # Generate I2C bus config message
         if sw_pins is not None:
             self.config_fmt = (
@@ -213,6 +220,7 @@ class MCU_I2C:
         return self.cmd_queue
 
     def build_config(self):
+        self.mcu.add_config_cmd("config_i2c oid=%d" % (self.oid,))
         if "%" in self.config_fmt:
             bus = resolve_bus_name(self.mcu, "i2c_bus", self.bus)
             self.config_fmt = self.config_fmt % (bus,)
@@ -297,6 +305,7 @@ def MCU_I2C_from_config(config, default_addr=None, default_speed=100000):
 # Bus synchronized digital outputs
 ######################################################################
 
+
 # Helper code for a gpio that updates on a cmd_queue
 class MCU_bus_digital_out:
     def __init__(self, mcu, pin_desc, cmd_queue=None, value=0):
@@ -304,15 +313,13 @@ class MCU_bus_digital_out:
         self.oid = mcu.create_oid()
         ppins = mcu.get_printer().lookup_object("pins")
         pin_params = ppins.lookup_pin(pin_desc)
+        self.pin_params = pin_params
+        self.value = value
         if pin_params["chip"] is not mcu:
             raise ppins.error(
                 "Pin %s must be on mcu %s" % (pin_desc, mcu.get_name())
             )
-        mcu.add_config_cmd(
-            "config_digital_out oid=%d pin=%s value=%d"
-            " default_value=%d max_duration=%d"
-            % (self.oid, pin_params["pin"], value, value, 0)
-        )
+
         mcu.register_config_callback(self.build_config)
         if cmd_queue is None:
             cmd_queue = mcu.alloc_command_queue()
@@ -329,6 +336,11 @@ class MCU_bus_digital_out:
         return self.cmd_queue
 
     def build_config(self):
+        self.mcu.add_config_cmd(
+            "config_digital_out oid=%d pin=%s value=%d"
+            " default_value=%d max_duration=%d"
+            % (self.oid, self.pin_params["pin"], self.value, self.value, 0)
+        )
         self.update_pin_cmd = self.mcu.lookup_command(
             "update_digital_out oid=%c value=%c", cq=self.cmd_queue
         )

--- a/klippy/extras/lis2dw.py
+++ b/klippy/extras/lis2dw.py
@@ -41,6 +41,7 @@ MIN_MSG_TIME = 0.100
 BYTES_PER_SAMPLE = 6
 SAMPLES_PER_BLOCK = 8
 
+
 # Printer class that controls LIS2DW chip
 class LIS2DW:
     def __init__(self, config):
@@ -69,12 +70,7 @@ class LIS2DW:
         self.oid = oid = mcu.create_oid()
         self.query_lis2dw_cmd = self.query_lis2dw_end_cmd = None
         self.query_lis2dw_status_cmd = None
-        mcu.add_config_cmd(
-            "config_lis2dw oid=%d spi_oid=%d" % (oid, self.spi.get_oid())
-        )
-        mcu.add_config_cmd(
-            "query_lis2dw oid=%d clock=0 rest_ticks=0" % (oid,), on_restart=True
-        )
+
         mcu.register_config_callback(self._build_config)
         mcu.register_response(self._handle_lis2dw_data, "lis2dw_data", oid)
         # Clock tracking
@@ -92,6 +88,13 @@ class LIS2DW:
         )
 
     def _build_config(self):
+        self.mcu.add_config_cmd(
+            "config_lis2dw oid=%d spi_oid=%d" % (self.oid, self.spi.get_oid())
+        )
+        self.mcu.add_config_cmd(
+            "query_lis2dw oid=%d clock=0 rest_ticks=0" % (self.oid,),
+            on_restart=True,
+        )
         cmdqueue = self.spi.get_command_queue()
         self.query_lis2dw_cmd = self.mcu.lookup_command(
             "query_lis2dw oid=%c clock=%u rest_ticks=%u", cq=cmdqueue

--- a/klippy/extras/mcp4018.py
+++ b/klippy/extras/mcp4018.py
@@ -20,10 +20,10 @@ class SoftwareI2C:
             self.scl_main = scl_params["class"] = self
             self.scl_oid = self.mcu.create_oid()
             self.cmd_queue = self.mcu.alloc_command_queue()
-            self.mcu.register_config_callback(self.build_config)
         else:
             self.scl_oid = self.scl_main.scl_oid
             self.cmd_queue = self.scl_main.cmd_queue
+        self.mcu.register_config_callback(self.build_config)
         sda_params = ppins.lookup_pin(config.get("sda_pin"))
         self.sda_oid = self.mcu.create_oid()
         if sda_params["chip"] != self.mcu:
@@ -31,24 +31,27 @@ class SoftwareI2C:
                 "%s: scl_pin and sda_pin must be on same mcu"
                 % (config.get_name(),)
             )
-        self.mcu.add_config_cmd(
-            "config_digital_out oid=%d pin=%s"
-            " value=%d default_value=%d max_duration=%d"
-            % (self.sda_oid, sda_params["pin"], 1, 1, 0)
-        )
+        self.sda_params = sda_params
 
     def get_mcu(self):
         return self.mcu
 
     def build_config(self):
         self.mcu.add_config_cmd(
-            "config_digital_out oid=%d pin=%s value=%d"
-            " default_value=%d max_duration=%d"
-            % (self.scl_oid, self.scl_pin, 1, 1, 0)
+            "config_digital_out oid=%d pin=%s"
+            " value=%d default_value=%d max_duration=%d"
+            % (self.sda_oid, self.sda_params["pin"], 1, 1, 0)
         )
-        self.update_pin_cmd = self.mcu.lookup_command(
-            "update_digital_out oid=%c value=%c", cq=self.cmd_queue
-        )
+
+        if self.scl_main is self:
+            self.mcu.add_config_cmd(
+                "config_digital_out oid=%d pin=%s value=%d"
+                " default_value=%d max_duration=%d"
+                % (self.scl_oid, self.scl_pin, 1, 1, 0)
+            )
+            self.update_pin_cmd = self.mcu.lookup_command(
+                "update_digital_out oid=%c value=%c", cq=self.cmd_queue
+            )
 
     def i2c_write(self, msg, minclock=0, reqclock=0):
         msg = [self.addr] + msg

--- a/klippy/extras/samd_sercom.py
+++ b/klippy/extras/samd_sercom.py
@@ -16,31 +16,39 @@ class SamdSERCOM:
 
         ppins = self.printer.lookup_object("pins")
         tx_pin_params = ppins.lookup_pin(self.tx_pin)
+        self.tx_pin_params = tx_pin_params
         self.mcu = tx_pin_params["chip"]
-        self.mcu.add_config_cmd(
-            "set_sercom_pin bus=%s sercom_pin_type=tx pin=%s"
-            % (self.sercom, tx_pin_params["pin"])
-        )
 
         clk_pin_params = ppins.lookup_pin(self.clk_pin)
+        self.clk_pin_params = clk_pin_params
         if self.mcu is not clk_pin_params["chip"]:
             raise ppins.error(
                 "%s: SERCOM pins must be on same mcu" % (config.get_name(),)
             )
-        self.mcu.add_config_cmd(
-            "set_sercom_pin bus=%s sercom_pin_type=clk pin=%s"
-            % (self.sercom, clk_pin_params["pin"])
-        )
 
         if self.rx_pin:
             rx_pin_params = ppins.lookup_pin(self.rx_pin)
+            self.rx_pin_params = rx_pin_params
             if self.mcu is not rx_pin_params["chip"]:
                 raise ppins.error(
                     "%s: SERCOM pins must be on same mcu" % (config.get_name(),)
                 )
+
+        self.mcu.register_config_callback()
+
+    def _build_config(self):
+        self.mcu.add_config_cmd(
+            "set_sercom_pin bus=%s sercom_pin_type=tx pin=%s"
+            % (self.sercom, self.tx_pin_params["pin"])
+        )
+        self.mcu.add_config_cmd(
+            "set_sercom_pin bus=%s sercom_pin_type=clk pin=%s"
+            % (self.sercom, self.clk_pin_params["pin"])
+        )
+        if self.rx_pin:
             self.mcu.add_config_cmd(
                 "set_sercom_pin bus=%s sercom_pin_type=rx pin=%s"
-                % (self.sercom, rx_pin_params["pin"])
+                % (self.sercom, self.rx_pin_params["pin"])
             )
 
 

--- a/klippy/extras/tmc_uart.py
+++ b/klippy/extras/tmc_uart.py
@@ -21,15 +21,16 @@ class MCU_analog_mux:
         self.oids = [self.mcu.create_oid() for pp in select_pin_params]
         self.pins = [pp["pin"] for pp in select_pin_params]
         self.pin_values = tuple([-1 for pp in select_pin_params])
+
+        self.update_pin_cmd = None
+        self.mcu.register_config_callback(self.build_config)
+
+    def build_config(self):
         for oid, pin in zip(self.oids, self.pins):
             self.mcu.add_config_cmd(
                 "config_digital_out oid=%d pin=%s"
                 " value=0 default_value=0 max_duration=0" % (oid, pin)
             )
-        self.update_pin_cmd = None
-        self.mcu.register_config_callback(self.build_config)
-
-    def build_config(self):
         self.update_pin_cmd = self.mcu.lookup_command(
             "update_digital_out oid=%c value=%c", cq=self.cmd_queue
         )
@@ -62,6 +63,7 @@ class MCU_analog_mux:
 # TMC uart communication
 ######################################################################
 
+
 # Share mutexes so only one active tmc_uart command on a single mcu at
 # a time. This helps limit cpu usage on slower micro-controllers.
 class PrinterTMCUartMutexes:
@@ -84,6 +86,7 @@ def lookup_tmc_uart_mutex(mcu):
 
 TMC_BAUD_RATE = 40000
 TMC_BAUD_RATE_AVR = 9000
+
 
 # Code for sending messages on a TMC uart
 class MCU_TMC_uart_bitbang:

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -938,6 +938,8 @@ class MCU:
         if self._oid_count == 0 and len(self._config_cmds) != 0:
             unique_oids = set()
             for cmd in self._config_cmds:
+                if "oid=" not in cmd:
+                    continue
                 oid = cmd.split(" oid=")[1][0]
                 unique_oids.add(oid)
             self._oid_count = len(unique_oids)

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -915,7 +915,7 @@ class MCU:
         self._reactor.update_timer(
             self.non_critical_recon_timer, self._reactor.NOW
         )
-        logging.info("mcu: %s disconnected", self._name)
+        logging.info("mcu: '%s' disconnected", self._name)
 
     def non_critical_recon_event(self, eventtime):
         self.recon_mcu()
@@ -925,6 +925,14 @@ class MCU:
         # Build config commands
         for cb in self._config_callbacks:
             cb()
+        # oid count is 0, but we have config cmds.
+        # figure out the oid count from the config cmds
+        if self._oid_count == 0 and len(self._config_cmds) != 0:
+            unique_oids = set()
+            for cmd in self._config_cmds:
+                oid = cmd.split(" oid=")[1][0]
+                unique_oids.add(oid)
+            self._oid_count = len(unique_oids)
         self._config_cmds.insert(
             0, "allocate_oids count=%d" % (self._oid_count,)
         )
@@ -1017,7 +1025,7 @@ class MCU:
         )
         self._reactor.unregister_timer(self.non_critical_recon_timer)
         self.last_noncrit_recon_eventtime = None
-        logging.info("mcu: %s reconnected", self._name)
+        logging.info("mcu: '%s' reconnected", self._name)
 
     def reset_to_initial_state(self):
         self._oid_count = 0
@@ -1040,6 +1048,7 @@ class MCU:
             if self._restart_method == "rpi_usb":
                 # Only configure mcu after usb power reset
                 self._check_restart("full reset before config")
+            logging.info("not configured, sending config...")
             # Not configured - send config and issue get_config again
             self._send_config(None)
             config_params = self._send_get_config()

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -758,7 +758,9 @@ class MCU:
             self._name = self._name[4:]
         # Serial port
         wp = "mcu '%s': " % (self._name)
-        self._serial = serialhdl.SerialReader(self._reactor, warn_prefix=wp)
+        self._serial = serialhdl.SerialReader(
+            self._reactor, warn_prefix=wp, mcu=self
+        )
         self._baud = 0
         self._canbus_iface = None
         canbus_uuid = config.get("canbus_uuid", None)
@@ -817,8 +819,7 @@ class MCU:
             self.non_critical_recon_event
         )
         self.is_non_critical = config.getboolean("is_non_critical", False)
-        self._non_critical_disconnected = False
-        # self.last_noncrit_recon_eventtime = None
+        self.non_critical_disconnected = False
         self.reconnect_interval = (
             config.getfloat("reconnect_interval", 2.0) + 0.12
         )  # add small change to not collide with other events
@@ -909,17 +910,23 @@ class MCU:
             self.estimated_print_time = dummy_estimated_print_time
 
     def handle_non_critical_disconnect(self):
-        self._non_critical_disconnected = True
+        self.non_critical_disconnected = True
         self._clocksync.disconnect()
         self._disconnect()
         self._reactor.update_timer(
-            self.non_critical_recon_timer, self._reactor.NOW
+            self.non_critical_recon_timer,
+            self._reactor.NOW + self.reconnect_interval,
         )
         logging.info("mcu: '%s' disconnected", self._name)
 
     def non_critical_recon_event(self, eventtime):
-        self.recon_mcu()
-        return eventtime + self.reconnect_interval
+        success = self.recon_mcu()
+        if success:
+            logging.info(f"mcu: '{self._name}' reconnected!")
+            return self._reactor.NEVER
+        else:
+            logging.info(f"mcu: '{self._name}' not connected!")
+            return eventtime + self.reconnect_interval
 
     def _send_config(self, prev_crc):
         # Build config commands
@@ -1017,15 +1024,15 @@ class MCU:
     def recon_mcu(self):
         res = self._mcu_identify()
         if not res:
-            return
+            return False
         self.reset_to_initial_state()
+        self.non_critical_disconnected = False
         self._connect()
-        self._reactor.update_timer(
-            self.non_critical_recon_timer, self._reactor.NEVER
-        )
-        self._reactor.unregister_timer(self.non_critical_recon_timer)
-        self.last_noncrit_recon_eventtime = None
-        logging.info("mcu: '%s' reconnected", self._name)
+        # self._reactor.update_timer(
+        #     self.non_critical_recon_timer, self._reactor.NEVER
+        # )
+        # self._reactor.unregister_timer(self.non_critical_recon_timer)
+        return True
 
     def reset_to_initial_state(self):
         self._oid_count = 0
@@ -1037,9 +1044,13 @@ class MCU:
         self._steppersync = None
 
     def _connect(self):
-        if self._non_critical_disconnected:
-            self.non_critical_recon_timer = self._reactor.register_timer(
-                self.non_critical_recon_event,
+        if self.non_critical_disconnected:
+            # self.non_critical_recon_timer = self._reactor.register_timer(
+            #     self.non_critical_recon_event,
+            #     self._reactor.NOW + self.reconnect_interval,
+            # )
+            self._reactor.update_timer(
+                self.non_critical_recon_timer,
                 self._reactor.NOW + self.reconnect_interval,
             )
             return
@@ -1089,10 +1100,10 @@ class MCU:
 
     def _mcu_identify(self):
         if self.is_non_critical and not self._check_serial_exists():
-            self._non_critical_disconnected = True
+            self.non_critical_disconnected = True
             return False
         else:
-            self._non_critical_disconnected = False
+            self.non_critical_disconnected = False
         if self.is_fileoutput():
             self._connect_file()
         else:
@@ -1296,7 +1307,7 @@ class MCU:
     def _firmware_restart(self, force=False):
         if (
             self._is_mcu_bridge and not force
-        ) or self._non_critical_disconnected:
+        ) or self.non_critical_disconnected:
             return
         if self._restart_method == "rpi_usb":
             self._restart_rpi_usb()

--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -14,7 +14,13 @@ class error(Exception):
 
 
 class SerialReader:
-    def __init__(self, reactor, warn_prefix=""):
+    def __init__(
+        self,
+        reactor,
+        warn_prefix="",
+        mcu=None,
+    ):
+        self.mcu = mcu
         self.reactor = reactor
         self.warn_prefix = warn_prefix
         # Serial port
@@ -293,8 +299,13 @@ class SerialReader:
             else:
                 self.handlers[name, oid] = callback
 
+    def _check_noncritical_disconnected(self):
+        if self.mcu is not None and self.mcu.non_critical_disconnected:
+            self._error("non-critical MCU is disconnected")
+
     # Command sending
     def raw_send(self, cmd, minclock, reqclock, cmd_queue):
+        self._check_noncritical_disconnected()
         if self.serialqueue is None:
             logging.info(
                 "%sSerial connection closed, cmd: %s",
@@ -307,6 +318,7 @@ class SerialReader:
         )
 
     def raw_send_wait_ack(self, cmd, minclock, reqclock, cmd_queue):
+        self._check_noncritical_disconnected()
         if self.serialqueue is None:
             logging.info(
                 "%sSerial connection closed, in wait ack, cmd: %s",


### PR DESCRIPTION
most klipper mcus weren't correctly reconnecting, this fixes

klipper extras mcu configuration pattern is that we should call mcu.add_config_cmd from the config callback. we didn't do that for most extras which caused issues. this moves the add_config_cmd calls from the `__init__` to the config callback for all extras