### PR TITLE
add bed_mesh_default option to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ If I want my printer to light itself on fire, I should be able to make my printe
 
 - [force_move: turn on by default](https://github.com/DangerKlippers/danger-klipper/pull/135)
 
+- [bed_mesh: add bed_mesh_default config option](https://github.com/DangerKlippers/danger-klipper/pull/143)
+
+
 If you're feeling adventurous, take a peek at the extra features in the bleeding-edge branch:
 
 - [dmbutyugin's advanced-features branch](https://github.com/DangerKlippers/danger-klipper/pull/69) [dmbutyugin/advanced-features](https://github.com/dmbutyugin/klipper/commits/advanced-features)
@@ -83,8 +86,6 @@ If you're feeling adventurous, take a peek at the extra features in the bleeding
 - [input_shaper: new print_ringing_tower utility](https://github.com/DangerKlippers/danger-klipper/pull/69)
 
 - [Independent X & Y Acceleration and velocity settings](https://github.com/DangerKlippers/danger-klipper/pull/4)
-
-- [bed_mesh: add bed_mesh_default config option](https://github.com/DangerKlippers/danger-klipper/pull/143)
 
 ## Switch to Danger Klipper
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ If you're feeling adventurous, take a peek at the extra features in the bleeding
 
 - [Independent X & Y Acceleration and velocity settings](https://github.com/DangerKlippers/danger-klipper/pull/4)
 
+- [bed_mesh: add bed_mesh_default config option](https://github.com/DangerKlippers/danger-klipper/pull/143)
+
 ## Switch to Danger Klipper
 
 > [!NOTE]

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1139,6 +1139,9 @@ Visual Examples:
 #adaptive_margin:
 #   An optional margin (in mm) to be added around the bed area used by
 #   the defined print objects when generating an adaptive mesh.
+#bed_mesh_default:
+#   Optionally provide the name of a profile you would like loaded on init.
+#   By default, no profile is loaded.
 ```
 
 ### [bed_tilt]

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -113,6 +113,7 @@ class BedMesh:
         self.printer.register_event_handler(
             "klippy:connect", self.handle_connect
         )
+        config_file = self.printer.lookup_object("configfile")
         self.last_position = [0.0, 0.0, 0.0, 0.0]
         self.bmc = BedMeshCalibrate(config, self)
         self.z_mesh = None
@@ -131,6 +132,16 @@ class BedMesh:
         # setup persistent storage
         self.pmgr = ProfileManager(config, self)
         self.save_profile = self.pmgr.save_profile
+        self.default_mesh_name = config.get("bed_mesh_default", None)
+        if self.default_mesh_name:
+            if self.default_mesh_name in self.pmgr.get_profiles():
+                self.pmgr.load_profile(self.default_mesh_name)
+            else:
+                config_file.warn(
+                    "config",
+                    f"Selected default bed mesh profile '{self.default_mesh_name}' not found in available profiles.",
+                    "Invalid profile name",
+                )
         # register gcodes
         self.gcode.register_command(
             "BED_MESH_OUTPUT",


### PR DESCRIPTION
See issue https://github.com/DangerKlippers/danger-klipper/issues/139
Behavior is as follows:
If bed_mesh_default is not defined, do nothing. If it is, continue.
If the requested mesh is not in the list of meshes, raise warning. If it is, load it.