### PR TITLE
added dual_carriage warning

### DIFF
--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -23,6 +23,7 @@ class CartKinematics:
         self.axes_min = toolhead.Coord(*[r[0] for r in ranges], e=0.0)
         self.axes_max = toolhead.Coord(*[r[1] for r in ranges], e=0.0)
         self.dc_module = None
+        self.supports_dual_carriage = True
         if config.has_section("dual_carriage"):
             dc_config = config.getsection("dual_carriage")
             dc_axis = dc_config.getchoice("axis", {"x": "x", "y": "y"})

--- a/klippy/kinematics/corexy.py
+++ b/klippy/kinematics/corexy.py
@@ -38,6 +38,7 @@ class CoreXYKinematics:
         ranges = [r.get_range() for r in self.rails]
         self.axes_min = toolhead.Coord(*[r[0] for r in ranges], e=0.0)
         self.axes_max = toolhead.Coord(*[r[1] for r in ranges], e=0.0)
+        self.supports_dual_carriage = False
 
     def get_steppers(self):
         return [s for rail in self.rails for s in rail.get_steppers()]

--- a/klippy/kinematics/corexz.py
+++ b/klippy/kinematics/corexz.py
@@ -38,6 +38,7 @@ class CoreXZKinematics:
         ranges = [r.get_range() for r in self.rails]
         self.axes_min = toolhead.Coord(*[r[0] for r in ranges], e=0.0)
         self.axes_max = toolhead.Coord(*[r[1] for r in ranges], e=0.0)
+        self.supports_dual_carriage = False
 
     def get_steppers(self):
         return [s for rail in self.rails for s in rail.get_steppers()]

--- a/klippy/kinematics/delta.py
+++ b/klippy/kinematics/delta.py
@@ -132,6 +132,7 @@ class DeltaKinematics:
         self.axes_min = toolhead.Coord(-max_xy, -max_xy, self.min_z, 0.0)
         self.axes_max = toolhead.Coord(max_xy, max_xy, self.max_z, 0.0)
         self.set_position([0.0, 0.0, 0.0], ())
+        self.supports_dual_carriage = False
 
     def get_steppers(self):
         return [s for rail in self.rails for s in rail.get_steppers()]

--- a/klippy/kinematics/deltesian.py
+++ b/klippy/kinematics/deltesian.py
@@ -120,6 +120,7 @@ class DeltesianKinematics:
         self.axes_max = toolhead.Coord(*[l[1] for l in self.limits], e=0.0)
         self.homed_axis = [False] * 3
         self.set_position([0.0, 0.0, 0.0], ())
+        self.supports_dual_carriage = False
 
     def get_steppers(self):
         return [s for rail in self.rails for s in rail.get_steppers()]

--- a/klippy/kinematics/hybrid_corexy.py
+++ b/klippy/kinematics/hybrid_corexy.py
@@ -27,6 +27,7 @@ class HybridCoreXYKinematics:
         self.axes_min = toolhead.Coord(*[r[0] for r in ranges], e=0.0)
         self.axes_max = toolhead.Coord(*[r[1] for r in ranges], e=0.0)
         self.dc_module = None
+        self.supports_dual_carriage = True
         if config.has_section("dual_carriage"):
             dc_config = config.getsection("dual_carriage")
             # dummy for cartesian config users

--- a/klippy/kinematics/hybrid_corexz.py
+++ b/klippy/kinematics/hybrid_corexz.py
@@ -27,6 +27,7 @@ class HybridCoreXZKinematics:
         self.axes_min = toolhead.Coord(*[r[0] for r in ranges], e=0.0)
         self.axes_max = toolhead.Coord(*[r[1] for r in ranges], e=0.0)
         self.dc_module = None
+        self.supports_dual_carriage = True
         if config.has_section("dual_carriage"):
             dc_config = config.getsection("dual_carriage")
             # dummy for cartesian config users

--- a/klippy/kinematics/limited_cartesian.py
+++ b/klippy/kinematics/limited_cartesian.py
@@ -86,6 +86,7 @@ class LimitedCartKinematics(cartesian.CartKinematics):
             self.cmd_SET_KINEMATICS_LIMIT,
             desc=self.cmd_SET_KINEMATICS_LIMIT_help,
         )
+        self.supports_dual_carriage = False
 
     cmd_SET_KINEMATICS_LIMIT_help = "Set/get cartesian per axis velocity limits"
 

--- a/klippy/kinematics/limited_corexy.py
+++ b/klippy/kinematics/limited_corexy.py
@@ -47,6 +47,7 @@ class LimitedCoreXYKinematics(corexy.CoreXYKinematics):
             self.cmd_SET_KINEMATICS_LIMIT,
             desc=self.cmd_SET_KINEMATICS_LIMIT_help,
         )
+        self.supports_dual_carriage = False
 
     cmd_SET_KINEMATICS_LIMIT_help = "Set/get CoreXY per axis velocity limits"
 

--- a/klippy/kinematics/none.py
+++ b/klippy/kinematics/none.py
@@ -8,6 +8,7 @@
 class NoneKinematics:
     def __init__(self, toolhead, config):
         self.axes_minmax = toolhead.Coord(0.0, 0.0, 0.0, 0.0)
+        self.supports_dual_carriage = False
 
     def get_steppers(self):
         return []

--- a/klippy/kinematics/polar.py
+++ b/klippy/kinematics/polar.py
@@ -42,6 +42,7 @@ class PolarKinematics:
         min_z, max_z = self.rails[1].get_range()
         self.axes_min = toolhead.Coord(-max_xy, -max_xy, min_z, 0.0)
         self.axes_max = toolhead.Coord(max_xy, max_xy, max_z, 0.0)
+        self.supports_dual_carriage = False
 
     def get_steppers(self):
         return list(self.steppers)

--- a/klippy/kinematics/rotary_delta.py
+++ b/klippy/kinematics/rotary_delta.py
@@ -111,6 +111,7 @@ class RotaryDeltaKinematics:
         self.axes_min = toolhead.Coord(-max_xy, -max_xy, self.min_z, 0.0)
         self.axes_max = toolhead.Coord(max_xy, max_xy, self.max_z, 0.0)
         self.set_position([0.0, 0.0, 0.0], ())
+        self.supports_dual_carriage = False
 
     def get_steppers(self):
         return [s for rail in self.rails for s in rail.get_steppers()]

--- a/klippy/kinematics/winch.py
+++ b/klippy/kinematics/winch.py
@@ -28,6 +28,7 @@ class WinchKinematics:
         self.axes_min = toolhead.Coord(*[min(a) for a in acoords], e=0.0)
         self.axes_max = toolhead.Coord(*[max(a) for a in acoords], e=0.0)
         self.set_position([0.0, 0.0, 0.0], ())
+        self.supports_dual_carriage = False
 
     def get_steppers(self):
         return list(self.steppers)

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -314,6 +314,14 @@ class ToolHead:
             msg = "Error loading kinematics '%s'" % (kin_name,)
             logging.exception(msg)
             raise config.error(msg)
+        if (
+            config.has_section("dual_carriage")
+            and not self.kin.supports_dual_carriage
+        ):
+            raise config.error(
+                "dual_carriage not compatible with '%s' kinematics system"
+                % (kin_name,)
+            )
         # Register commands
         gcode.register_command("G4", self.cmd_G4)
         gcode.register_command("M400", self.cmd_M400)


### PR DESCRIPTION
#115

Added explicit flags in each kinematic type for dual carriage support.
Added check in toolhead.py for:
If config contains dual_carriage AND its not supported, throw error.