### PR TITLE
Update stm32h7.c

### DIFF
--- a/src/stm32/stm32h7.c
+++ b/src/stm32/stm32h7.c
@@ -98,9 +98,14 @@ clock_setup(void)
     PWR->CR3 = (PWR->CR3 | PWR_CR3_LDOEN) & ~(PWR_CR3_BYPASS | PWR_CR3_SCUEN);
     while (!(PWR->CSR1 & PWR_CSR1_ACTVOSRDY))
         ;
-    // (HSE 25mhz) /DIVM1(5) (pll_base 5Mhz) *DIVN1(192) (pll_freq 960Mhz)
-    // /DIVP1(2) (SYSCLK 480Mhz)
+// klipper supports 8, 12, 16, 20, 24, and 25 MHz crystals on HSE
+#if CONFIG_CLOCK_REF_FREQ % 5000000 == 0
     uint32_t pll_base = 5000000;
+#elif CONFIG_CLOCK_REF_FREQ % 4000000 == 0
+    uint32_t pll_base = 4000000;
+#else
+#error Unknown pll_base for CLOCK_REF_FREQ
+#endif
     // Only even dividers (DIVP1) are allowed
     uint32_t pll_freq = CONFIG_CLOCK_FREQ * 2;
     if (!CONFIG_STM32_CLOCK_REF_INTERNAL) {


### PR DESCRIPTION
This fixes https://github.com/DangerKlippers/danger-klipper/issues/147 where pll_base is hard-coded to a value of 5 MHz, which works nominally for boards with a 25 MHz crystal on HSE but fails for 12 MHz and other values that do not evenly divide into 5 MHz when configuring the DIVM1 prescaler.

Thanks @dalegaard for the help.

May want to test against a board with a 25 MHz crystal before merging, and we may also want to check if this bug exists for other stm32 clock configs