### PR TITLE
Nozzle warning

### DIFF
--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -219,6 +219,7 @@ class PrinterExtruder:
         self.name = config.get_name()
         self.last_position = 0.0
         # Setup hotend heater
+        config_file = self.printer.lookup_object("configfile")
         shared_heater = config.get("shared_heater", None)
         pheaters = self.printer.load_object(config, "heaters")
         gcode_id = "T%d" % (extruder_num,)
@@ -230,6 +231,12 @@ class PrinterExtruder:
         # Setup kinematic checks
         self.nozzle_diameter = config.getfloat("nozzle_diameter", above=0.0)
         filament_diameter = config.getfloat("filament_diameter")
+        if filament_diameter < self.nozzle_diameter:
+            config_file.warn(
+                "config",
+                f"Nozzle diameter ({self.nozzle_diameter}mm) is larger than filament diameter ({filament_diameter}mm).",
+                "Invalid profile name",
+            )
         self.filament_area = math.pi * (filament_diameter * 0.5) ** 2
         def_max_cross_section = 4.0 * self.nozzle_diameter**2
         def_max_extrude_ratio = def_max_cross_section / self.filament_area

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -229,9 +229,7 @@ class PrinterExtruder:
             self.heater = pheaters.lookup_heater(shared_heater)
         # Setup kinematic checks
         self.nozzle_diameter = config.getfloat("nozzle_diameter", above=0.0)
-        filament_diameter = config.getfloat(
-            "filament_diameter", minval=self.nozzle_diameter
-        )
+        filament_diameter = config.getfloat("filament_diameter")
         self.filament_area = math.pi * (filament_diameter * 0.5) ** 2
         def_max_cross_section = 4.0 * self.nozzle_diameter**2
         def_max_extrude_ratio = def_max_cross_section / self.filament_area

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -230,7 +230,7 @@ class PrinterExtruder:
             self.heater = pheaters.lookup_heater(shared_heater)
         # Setup kinematic checks
         self.nozzle_diameter = config.getfloat("nozzle_diameter", above=0.0)
-        filament_diameter = config.getfloat("filament_diameter")
+        filament_diameter = config.getfloat("filament_diameter", above=0.0)
         if filament_diameter < self.nozzle_diameter:
             config_file.warn(
                 "config",


### PR DESCRIPTION
Refer to https://github.com/Klipper3d/klipper/issues/5164


Removed minval from filament diameter, added warning if nozzle_diameter is larger than filament_diameter. This is helpful for users with CHT nozzles larger than filament diameter (assuming they didnt override it already using max_extrude_cross_section).