### PR TITLE
temperature_fan: fix fan never turning off when not reversed

### DIFF
--- a/klippy/extras/temperature_fan.py
+++ b/klippy/extras/temperature_fan.py
@@ -151,7 +151,7 @@ class ControlBangBang:
         ):
             self.heating = self.reverse
         elif (
-            not self.heating == self.reverse
+            self.heating == self.reverse
             and temp <= target_temp - self.max_delta
         ):
             self.heating = not self.reverse


### PR DESCRIPTION
This fixes that `temperature_fan` with `control: watermark` never turns off when reverse is set to `False` (the default value).