### PR TITLE
Changed SAVE_CONFIG to update include configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ If I want my printer to light itself on fire, I should be able to make my printe
 
 - [bed_mesh: add bed_mesh_default config option](https://github.com/DangerKlippers/danger-klipper/pull/143)
 
+- [config: CONFIG_SAVE updates included files](https://github.com/DangerKlippers/danger-klipper/pull/153)
 
 If you're feeling adventurous, take a peek at the extra features in the bleeding-edge branch:
 

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -115,6 +115,10 @@ A collection of DangerKlipper-specific system options
 #   limits for ADC temperature sensors. It prevents shutdowns due to
 #   'ADC out of range' errors by allowing readings outside the specified
 #   range without triggering a shutdown. Default is False.
+#autosave_includes: False
+#   When set to true, SAVE_CONFIG will recursively read [include ...] blocks
+#   for conflicts to autosave data. Any configurations updated will be backed
+#   up to configs/config_backups.
 ```
 
 ## Common kinematic settings

--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -565,6 +565,95 @@ class PrinterConfig:
 
     cmd_SAVE_CONFIG_help = "Overwrite config file and restart"
 
+    def _write_backup(self, cfgpath, cfgdata, gcode):
+        printercfg = self.printer.get_start_args()["config_file"]
+        configdir = os.path.dirname(printercfg)
+        # Define a directory for configuration backups so that include blocks
+        # using a wildcard to reference all files in a directory don't throw
+        # errors
+        backupdir = os.path.join(configdir, "config_backups")
+        # Create the backup directory if it doesn't already exist
+        if not os.path.exists(backupdir):
+            os.mkdir(backupdir)
+
+        # Generate the name of the backup file by stripping the leading path in
+        # `cfgpath` and appending to it. Then add it to the config_backups dir
+        datestr = time.strftime("-%Y%m%d_%H%M%S")
+        cfgname = os.path.basename(cfgpath)
+        backup_path = backupdir + "/" + cfgname + datestr
+        if cfgpath.endswith(".cfg"):
+            backup_path = backupdir + "/" + cfgname[:-4] + datestr + ".cfg"
+        logging.info(
+            "SAVE_CONFIG to '%s' (backup in '%s')", cfgpath, backup_path
+        )
+        try:
+            # Read the current config into the backup before making changes to
+            # the original file
+            currentconfig = open(cfgpath, "r")
+            backupconfig = open(backup_path, "w")
+            backupconfig.write(currentconfig.read())
+            backupconfig.close()
+            currentconfig.close()
+            # With the backup created, write the new data to the original file
+            currentconfig = open(cfgpath, "w")
+            currentconfig.write(cfgdata)
+            currentconfig.close()
+        except:
+            msg = "Unable to write config file during SAVE_CONFIG"
+            logging.exception(msg)
+            raise gcode.error(msg)
+
+    def _save_includes(self, cfgpath, data, visitedpaths, gcode):
+        # Prevent an infinite loop in the event of configs circularly
+        # referencing each other
+        if cfgpath in visitedpaths:
+            return
+
+        visitedpaths.add(cfgpath)
+        dirname = os.path.dirname(cfgpath)
+        # Read the data as individual lines so we can find include blocks
+        lines = data.split("\n")
+        for line in lines:
+            # Strip trailing comment
+            pos = line.find("#")
+            if pos >= 0:
+                line = line[:pos]
+
+            mo = configparser.RawConfigParser.SECTCRE.match(line)
+            header = mo and mo.group("header")
+            if header and header.startswith("include "):
+                include_spec = header[8:].strip()
+                include_glob = os.path.join(dirname, include_spec)
+                # retrieve all filenames associated with the absolute path of
+                # the include header
+                include_filenames = glob.glob(include_glob)
+                if not include_filenames and not glob.has_magic(include_glob):
+                    # Empty set is OK if wildcard but not for direct file
+                    # reference
+                    raise error(
+                        "Include file '%s' does not exist" % (include_glob,)
+                    )
+                include_filenames.sort()
+                # Read the include files and check them against autosave data.
+                # If autosave data overwites anything we'll update the file
+                # and create a backup.
+                for include_filename in include_filenames:
+                    # Recursively check for includes. No need to check for looping
+                    # includes as klipper checks this at startup.
+                    include_predata = self._read_config_file(include_filename)
+                    self._save_includes(
+                        include_filename, include_predata, visitedpaths, gcode
+                    )
+
+                    include_postdata = self._strip_duplicates(
+                        include_predata, self.autosave
+                    )
+                    # Only write and backup data that's been changed
+                    if include_predata != include_postdata:
+                        self._write_backup(
+                            include_filename, include_postdata, gcode
+                        )
+
     def cmd_SAVE_CONFIG(self, gcmd):
         if not self.autosave.fileconfig.sections():
             return
@@ -586,28 +675,15 @@ class PrinterConfig:
             logging.exception(msg)
             raise gcode.error(msg)
         regular_data = self._strip_duplicates(regular_data, self.autosave)
+
+        self.danger_options = self.printer.lookup_object("danger_options")
+        if self.danger_options.autosave_includes:
+            self._save_includes(cfgname, data, gcode, set())
+
+        # NOW we're safe to check for conflicts
         self._disallow_include_conflicts(regular_data, cfgname, gcode)
         data = regular_data.rstrip() + autosave_data
-        # Determine filenames
-        datestr = time.strftime("-%Y%m%d_%H%M%S")
-        backup_name = cfgname + datestr
-        temp_name = cfgname + "_autosave"
-        if cfgname.endswith(".cfg"):
-            backup_name = cfgname[:-4] + datestr + ".cfg"
-            temp_name = cfgname[:-4] + "_autosave.cfg"
-        # Create new config file with temporary name and swap with main config
-        logging.info(
-            "SAVE_CONFIG to '%s' (backup in '%s')", cfgname, backup_name
-        )
-        try:
-            f = open(temp_name, "w")
-            f.write(data)
-            f.close()
-            os.rename(cfgname, backup_name)
-            os.rename(temp_name, cfgname)
-        except:
-            msg = "Unable to write config file during SAVE_CONFIG"
-            logging.exception(msg)
-            raise gcode.error(msg)
+        self._write_backup(cfgname, data, gcode)
+
         # Request a restart
         gcode.request_restart("restart")

--- a/klippy/extras/danger_options.py
+++ b/klippy/extras/danger_options.py
@@ -23,6 +23,7 @@ class DangerOptions:
             "homing_elapsed_distance_tolerance", 0.5, minval=0.0
         )
         self.adc_ignore_limits = config.getboolean("adc_ignore_limits", False)
+        self.autosave_includes = config.getboolean("autosave_includes", False)
 
 
 def load_config(config):

--- a/test/klippy/danger_options.cfg
+++ b/test/klippy/danger_options.cfg
@@ -9,6 +9,7 @@ log_shutdown_info: False
 allow_plugin_override: True
 multi_mcu_trsync_timeout: 0.05
 adc_ignore_limits: True
+autosave_includes: True
 
 [stepper_x]
 step_pin: PF0


### PR DESCRIPTION
Proceeding under my own merits for #151, regarding #149

This update provides two changes to how autosave data is handled via klipper. The first is that included configs are now updated properly. In order to do this, the second change, a dedicated backups directory has been introduced; the importance of which is covered in further detail below. The backups directory will be created in the default configs directory for the printer.

The choice to make autosaving `include`s the danger option rather than the alternate backups directory is two-fold. Changing the path that a backup is saved to won't have any negative impact given that the path is pulled from klippy itself, then appended with the directory name. Additionally, code complexity and failure risk were considered for both options.

I've done my best to provide short but descriptive comments so the code can be easily understood.

More detailed information about the updates:

First is the desire to process included files during SAVE_CONFIG. As I'm sure is known, SAVE_CONFIG in its current state will only apply autosave data to `printer.cfg`. This results in conflicts when something such as PID values are stored in a separate config file. The proposed changes will sift through all of the config files used to instruct machine operation for conflicts with autosave data and comment them out.

The second change, the `config_backups` directory, was brought along out of necessity. During testing, @lraithel15133  was using a machine that had all of his additional config files in a single folder. Then, a `[include foldername/*.cfg]` was used for simplicity and to ensure that any new config additions were automatically loaded. Since the naming scheme that klipper uses for backing up configs retains the `.cfg` extension, the backups saved to the `foldername` directory were loaded via the include block resulting in error from `_disallow_include_conflicts`. Rather than change the naming format that klipper uses for backup files and potentially causing issues downstream with mainsail / fluid, the decision was made to add a directory specific for backup configs.