### PR TITLE
filament_switch_sensor: runout distance, smart and runout gcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ If I want my printer to light itself on fire, I should be able to make my printe
 
 - [canbus: custom CAN bus uuid hash for deterministic uuids](https://github.com/DangerKlippers/danger-klipper/pull/156)
 
+- [filament_switch|motion_sensor:  runout distance, smart and runout gcode](https://github.com/DangerKlippers/danger-klipper/pull/158)
+
 If you're feeling adventurous, take a peek at the extra features in the bleeding-edge branch [feature documentation](docs/Bleeding_Edge.md)
 and [feature configuration reference](docs/Config_Reference_Bleeding_Edge.md):
 

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -4764,11 +4764,22 @@ more information.
 #   detected. See docs/Command_Templates.md for G-Code format. If
 #   pause_on_runout is set to True this G-Code will run after the
 #   PAUSE is complete. The default is not to run any G-Code commands.
+#immediate_runout_gcode:
+#   A list of G-Code commands to execute immediately after a filament
+#   runout is detected and runout_distance is greater than 0.
+#   See docs/Command_Templates.md for G-Code format.
 #insert_gcode:
 #   A list of G-Code commands to execute after a filament insert is
 #   detected. See docs/Command_Templates.md for G-Code format. The
 #   default is not to run any G-Code commands, which disables insert
 #   detection.
+#runout_distance: 0.0
+#   Defines how much filament can still be pulled after the
+#   switch sensor triggered (e.g. you have a 60cm reverse bowden between your
+#   extruder and your sensor, you would then set runout_distance to something
+#   like 590 to leave a small safety margin and now the print will not
+#   immediately pause when the sensor triggers but rather keep printing until
+#   the filament is at the extruder). The default is 0 millimeters.
 #event_delay: 3.0
 #   The minimum amount of time in seconds to delay between events.
 #   Events triggered during this time period will be silently
@@ -4781,6 +4792,10 @@ more information.
 #switch_pin:
 #   The pin on which the switch is connected. This parameter must be
 #   provided.
+#smart:
+#   If set to true the sensor will use the virtual_sd_card module to determine
+#   whether the printer is printing which is more reliable but will not work
+#   when streaming a print over usb or similar.
 ```
 
 ### [filament_motion_sensor]
@@ -4807,6 +4822,7 @@ switch_pin:
 #insert_gcode:
 #event_delay:
 #pause_delay:
+#smart:
 #   See the "filament_switch_sensor" section for a description of the
 #   above parameters.
 ```

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -510,9 +510,31 @@ status of the filament sensor. The data displayed on the terminal will
 depend on the sensor type defined in the configuration.
 
 #### SET_FILAMENT_SENSOR
-`SET_FILAMENT_SENSOR SENSOR=<sensor_name> ENABLE=[0|1]`: Sets the
-filament sensor on/off. If ENABLE is set to 0, the filament sensor
-will be disabled, if set to 1 it is enabled.
+###### For filament_switch_sensor:
+`SET_FILAMENT_SENSOR SENSOR=<sensor_name> [ENABLE=0|1] [RESET=0|1]
+[RUNOUT_DISTANCE=<mm>] [SMART=0|1]`: Sets values for the
+filament sensor.  If all parameters are omitted, the current stats will
+be reported. <br>
+ENABLE sets the filament sensor on/off. If ENABLE is set to 0, the
+filament sensor will be disabled, if set to 1 it is enabled. If the state
+of the sensor changes, a reset will be triggered. <br>
+RESET removes all pending runout_gcodes and pauses and force a reevaluation
+of the sensor state. <br>
+RUNOUT_DISTANCE sets the runout_distance. <br>
+SMART sets the smart parameter.
+
+###### For filament_motion_sensor:
+`SET_FILAMENT_SENSOR SENSOR=<sensor_name> [ENABLE=0|1] [RESET=0|1]
+[DETECTION_LENGTH=<mm>] [SMART=0|1]`: Sets values for the
+filament sensor.  If all parameters are omitted, the current stats will
+be reported. <br>
+ENABLE sets the filament sensor on/off. If ENABLE is set to 0, the
+filament sensor will be disabled, if set to 1 it is enabled. If the sensor
+was previously disabled and gets enabled, a reset will be triggered. <br>
+RESET resets the state of the sensor and sets it to filament detected. <br>
+DETECTION_LENGTH sets the detection_length, if the new detection length is
+different from the old one, a reset will be triggered. <br>
+SMART sets the smart parameter.
 
 ### [firmware_retraction]
 

--- a/klippy/extras/filament_motion_sensor.py
+++ b/klippy/extras/filament_motion_sensor.py
@@ -103,20 +103,20 @@ class EncoderSensor:
         detection_length = gcmd.get_float("DETECTION_LENGTH", None, minval=0.0)
         if detection_length is None:
             gcmd.respond_info(self.get_sensor_status())
-            return 1
-        return 0
+            return True
+        return False
 
-    def enable(self, enable):
+    def reset_needed(self, enable):
         if enable and not self.runout_helper.sensor_enabled:
-            return 1
-        return 0
+            return True
+        return False
 
     def set_filament_sensor(self, gcmd):
-        reset = 0
+        reset = False
         detection_length = gcmd.get_float("DETECTION_LENGTH", None, minval=0.0)
         if detection_length is not None:
             if detection_length != self.detection_length:
-                reset = 1
+                reset = True
             self.detection_length = detection_length
         return reset
 

--- a/klippy/extras/filament_motion_sensor.py
+++ b/klippy/extras/filament_motion_sensor.py
@@ -12,6 +12,7 @@ class EncoderSensor:
     def __init__(self, config):
         # Read config
         self.printer = config.get_printer()
+        self.gcode = self.printer.lookup_object("gcode")
         switch_pin = config.get("switch_pin")
         self.extruder_name = config.get("extruder")
         self.detection_length = config.getfloat(
@@ -22,7 +23,7 @@ class EncoderSensor:
         buttons.register_buttons([switch_pin], self.encoder_event)
         # Get printer objects
         self.reactor = self.printer.get_reactor()
-        self.runout_helper = filament_switch_sensor.RunoutHelper(config)
+        self.runout_helper = filament_switch_sensor.RunoutHelper(config, self)
         self.get_status = self.runout_helper.get_status
         self.extruder = None
         self.estimated_print_time = None
@@ -87,6 +88,41 @@ class EncoderSensor:
             # Check for filament insertion
             # Filament is always assumed to be present on an encoder event
             self.runout_helper.note_filament_present(True)
+
+    def get_sensor_status(self):
+        return "Filament Sensor %s: %s\n" "Detection Length: %.2f" % (
+            self.runout_helper.name,
+            "enabled" if self.runout_helper.sensor_enabled > 0 else "disabled",
+            self.detection_length,
+        )
+
+    def sensor_get_status(self, eventtime):
+        return {"detection_length": float(self.detection_length)}
+
+    def get_info(self, gcmd):
+        detection_length = gcmd.get_float("DETECTION_LENGTH", None, minval=0.0)
+        if detection_length is None:
+            gcmd.respond_info(self.get_sensor_status())
+            return 1
+        return 0
+
+    def enable(self, enable):
+        if enable and not self.runout_helper.sensor_enabled:
+            return 1
+        return 0
+
+    def set_filament_sensor(self, gcmd):
+        reset = 0
+        detection_length = gcmd.get_float("DETECTION_LENGTH", None, minval=0.0)
+        if detection_length is not None:
+            if detection_length != self.detection_length:
+                reset = 1
+            self.detection_length = detection_length
+        return reset
+
+    def reset(self):
+        self._update_filament_runout_pos()
+        self.runout_helper.note_filament_present(True)
 
 
 def load_config_prefix(config):

--- a/klippy/extras/filament_motion_sensor.py
+++ b/klippy/extras/filament_motion_sensor.py
@@ -90,10 +90,22 @@ class EncoderSensor:
             self.runout_helper.note_filament_present(True)
 
     def get_sensor_status(self):
-        return "Filament Sensor %s: %s\n" "Detection Length: %.2f" % (
-            self.runout_helper.name,
-            "enabled" if self.runout_helper.sensor_enabled > 0 else "disabled",
-            self.detection_length,
+        return (
+            "Filament Sensor %s: %s\n"
+            "Filament Detected: %s\n"
+            "Detection Length: %.2f\n"
+            "Smart: %s"
+            % (
+                self.runout_helper.name,
+                (
+                    "enabled"
+                    if self.runout_helper.sensor_enabled > 0
+                    else "disabled"
+                ),
+                "true" if self.runout_helper.filament_present else "false",
+                self.detection_length,
+                "true" if self.runout_helper.smart else "false",
+            )
         )
 
     def sensor_get_status(self, eventtime):
@@ -112,13 +124,13 @@ class EncoderSensor:
         return False
 
     def set_filament_sensor(self, gcmd):
-        reset = False
+        reset_needed = False
         detection_length = gcmd.get_float("DETECTION_LENGTH", None, minval=0.0)
         if detection_length is not None:
             if detection_length != self.detection_length:
-                reset = True
+                reset_needed = True
             self.detection_length = detection_length
-        return reset
+        return reset_needed
 
     def reset(self):
         self._update_filament_runout_pos()

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -172,7 +172,8 @@ class RunoutHelper:
             "enabled": bool(self.sensor_enabled),
             "smart": bool(self.smart),
         }
-        return self.defined_sensor.sensor_get_status(eventtime).update(status)
+        status.update(self.defined_sensor.sensor_get_status(eventtime))
+        return status
 
     cmd_QUERY_FILAMENT_SENSOR_help = "Query the status of the Filament Sensor"
 

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -156,7 +156,6 @@ class RunoutHelper:
                     % (self.name, eventtime)
                 )
                 self.reactor.register_callback(self._insert_event_handler)
-        # elif self.runout_gcode is not None:
         elif is_printing and self.runout_gcode is not None:
             # runout detected
             self.min_event_systime = self.reactor.NEVER

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -7,8 +7,9 @@ import logging
 
 
 class RunoutHelper:
-    def __init__(self, config):
+    def __init__(self, config, defined_sensor, runout_distance=0):
         self.name = config.get_name().split()[-1]
+        self.defined_sensor = defined_sensor
         self.printer = config.get_printer()
         self.reactor = self.printer.get_reactor()
         self.gcode = self.printer.lookup_object("gcode")
@@ -16,7 +17,9 @@ class RunoutHelper:
         self.runout_pause = config.getboolean("pause_on_runout", True)
         if self.runout_pause:
             self.printer.load_object(config, "pause_resume")
-        self.runout_gcode = self.insert_gcode = None
+        self.runout_gcode = None
+        self.immediate_runout_gcode = None
+        self.insert_gcode = None
         gcode_macro = self.printer.load_object(config, "gcode_macro")
         if self.runout_pause or config.get("runout_gcode", None) is not None:
             self.runout_gcode = gcode_macro.load_template(
@@ -26,14 +29,23 @@ class RunoutHelper:
             self.insert_gcode = gcode_macro.load_template(
                 config, "insert_gcode"
             )
-        self.pause_delay = config.getfloat("pause_delay", 0.5, above=0.0)
-        self.event_delay = config.getfloat("event_delay", 3.0, above=0.0)
+        self.pause_delay = config.getfloat("pause_delay", 0.5, minval=0.0)
+        self.event_delay = config.getfloat("event_delay", 3.0, minval=0.0)
+        self.runout_distance = runout_distance
         # Internal state
         self.min_event_systime = self.reactor.NEVER
         self.filament_present = False
         self.sensor_enabled = True
+        self.smart = config.getboolean("smart", False)
+        self.runout_position = 0.0
+        self.runout_elapsed = 0.0
+        self.runout_distance_timer = None
+        self.force_trigger = False
         # Register commands and event handlers
         self.printer.register_event_handler("klippy:ready", self._handle_ready)
+        self.printer.register_event_handler(
+            "idle_timeout:printing", self._handle_printing
+        )
         self.gcode.register_mux_command(
             "QUERY_FILAMENT_SENSOR",
             "SENSOR",
@@ -52,9 +64,26 @@ class RunoutHelper:
     def _handle_ready(self):
         self.min_event_systime = self.reactor.monotonic() + 2.0
 
+    def _handle_printing(self, print_time):
+        self.note_filament_present(self.filament_present, True)
+
     def _runout_event_handler(self, eventtime):
+        if self.immediate_runout_gcode is not None:
+            self._exec_gcode("", self.immediate_runout_gcode)
         # Pausing from inside an event requires that the pause portion
         # of pause_resume execute immediately.
+        if self.runout_distance > 0:
+            if self.runout_distance_timer is None:
+                self.runout_position = self.defined_sensor.get_extruder_pos(
+                    eventtime
+                )
+                self.runout_distance_timer = self.reactor.register_timer(
+                    self._pause_after_distance, self.reactor.NOW
+                )
+        else:
+            self._execute_runout(eventtime)
+
+    def _execute_runout(self, eventtime):
         pause_prefix = ""
         if self.runout_pause:
             pause_resume = self.printer.lookup_object("pause_resume")
@@ -62,6 +91,26 @@ class RunoutHelper:
             pause_prefix = "PAUSE\n"
             self.printer.get_reactor().pause(eventtime + self.pause_delay)
         self._exec_gcode(pause_prefix, self.runout_gcode)
+        self.reset_runout_distance_info()
+
+    def reset_runout_distance_info(self):
+        self.runout_elapsed = 0.0
+        if self.runout_distance_timer is not None:
+            self.reactor.unregister_timer(self.runout_distance_timer)
+            self.runout_distance_timer = None
+
+    def _pause_after_distance(self, eventtime):
+        runout_elapsed = max(
+            0.0,
+            self.defined_sensor.get_extruder_pos(eventtime)
+            - self.runout_position,
+        )
+        if runout_elapsed < self.runout_distance:
+            self.runout_elapsed = runout_elapsed
+            return eventtime + CHECK_RUNOUT_TIMEOUT
+        else:
+            self._execute_runout(eventtime)
+            return self.reactor.NEVER
 
     def _insert_event_handler(self, eventtime):
         self._exec_gcode("", self.insert_gcode)
@@ -73,19 +122,30 @@ class RunoutHelper:
             logging.exception("Script running error")
         self.min_event_systime = self.reactor.monotonic() + self.event_delay
 
-    def note_filament_present(self, is_filament_present):
-        if is_filament_present == self.filament_present:
+    def note_filament_present(self, is_filament_present, force=False):
+        if is_filament_present == self.filament_present and not force:
             return
         self.filament_present = is_filament_present
         eventtime = self.reactor.monotonic()
-        if eventtime < self.min_event_systime or not self.sensor_enabled:
+        if eventtime < self.min_event_systime:
             # do not process during the initialization time, duplicates,
             # during the event delay time, while an event is running, or
             # when the sensor is disabled
             return
+        if is_filament_present:
+            self.printer.send_event("filament:insert", eventtime, self.name)
+        else:
+            self.printer.send_event("filament:runout", eventtime, self.name)
+        if not self.sensor_enabled:
+            return
         # Determine "printing" status
         idle_timeout = self.printer.lookup_object("idle_timeout")
-        is_printing = idle_timeout.get_status(eventtime)["state"] == "Printing"
+        print_stats = self.printer.lookup_object("print_stats")
+        is_printing = (
+            print_stats.get_status(eventtime)["state"] == "printing"
+            if self.smart
+            else idle_timeout.get_status(eventtime)["state"] == "Printing"
+        )
         # Perform filament action associated with status change (if any)
         if is_filament_present:
             if not is_printing and self.insert_gcode is not None:
@@ -96,6 +156,7 @@ class RunoutHelper:
                     % (self.name, eventtime)
                 )
                 self.reactor.register_callback(self._insert_event_handler)
+        # elif self.runout_gcode is not None:
         elif is_printing and self.runout_gcode is not None:
             # runout detected
             self.min_event_systime = self.reactor.NEVER
@@ -106,37 +167,116 @@ class RunoutHelper:
             self.reactor.register_callback(self._runout_event_handler)
 
     def get_status(self, eventtime):
-        return {
+        status = {
             "filament_detected": bool(self.filament_present),
             "enabled": bool(self.sensor_enabled),
+            "smart": bool(self.smart),
         }
+        return self.defined_sensor.sensor_get_status(eventtime).update(status)
 
     cmd_QUERY_FILAMENT_SENSOR_help = "Query the status of the Filament Sensor"
 
     def cmd_QUERY_FILAMENT_SENSOR(self, gcmd):
-        if self.filament_present:
-            msg = "Filament Sensor %s: filament detected" % (self.name)
-        else:
-            msg = "Filament Sensor %s: filament not detected" % (self.name)
+        msg = "Filament Sensor %s: filament %s" % (
+            self.name,
+            "detected" if self.filament_present else "not detected",
+        )
         gcmd.respond_info(msg)
 
     cmd_SET_FILAMENT_SENSOR_help = "Sets the filament sensor on/off"
 
     def cmd_SET_FILAMENT_SENSOR(self, gcmd):
-        self.sensor_enabled = gcmd.get_int("ENABLE", 1)
+        enable = gcmd.get_int("ENABLE", None, minval=0, maxval=1)
+        reset = gcmd.get_int("RESET", None, minval=0, maxval=1)
+        smart = gcmd.get_int("SMART", None, minval=0, maxval=1)
+        if (
+            enable is None
+            and reset is None
+            and smart is None
+            and self.defined_sensor.get_info(gcmd)
+        ):
+            return
+        if enable is not None:
+            if self.defined_sensor.enable(enable):
+                reset = 1
+            self.sensor_enabled = enable
+        if smart is not None:
+            self.smart = smart
+        if self.defined_sensor.set_filament_sensor(gcmd):
+            reset = 1
+        if reset is not None and reset:
+            self.defined_sensor.reset()
 
 
 class SwitchSensor:
     def __init__(self, config):
-        printer = config.get_printer()
-        buttons = printer.load_object(config, "buttons")
+        self.printer = config.get_printer()
+        gcode_macro = self.printer.load_object(config, "gcode_macro")
+        buttons = self.printer.load_object(config, "buttons")
         switch_pin = config.get("switch_pin")
+        runout_distance = config.getfloat("runout_distance", 0.0, minval=0.0)
         buttons.register_buttons([switch_pin], self._button_handler)
-        self.runout_helper = RunoutHelper(config)
+        self.reactor = self.printer.get_reactor()
+        self.estimated_print_time = None
+        self.runout_helper = RunoutHelper(config, self, runout_distance)
+        if config.get("immediate_runout_gcode", None) is not None:
+            self.runout_helper.immediate_runout_gcode = (
+                gcode_macro.load_template(config, "immediate_runout_gcode", "")
+            )
         self.get_status = self.runout_helper.get_status
+        self.printer.register_event_handler("klippy:ready", self._handle_ready)
+
+    def _handle_ready(self):
+        self.estimated_print_time = self.printer.lookup_object(
+            "mcu"
+        ).estimated_print_time
 
     def _button_handler(self, eventtime, state):
         self.runout_helper.note_filament_present(state)
+
+    def get_extruder_pos(self, eventtime=None):
+        if eventtime is None:
+            eventtime = self.reactor.monotonic()
+        print_time = self.estimated_print_time(eventtime)
+        extruder = self.printer.lookup_object("toolhead").get_extruder()
+        return extruder.find_past_position(print_time)
+
+    def get_sensor_status(self):
+        return "Filament Sensor %s: %s\n" "Runout Distance: %.2f" % (
+            self.runout_helper.name,
+            "enabled" if self.runout_helper.sensor_enabled else "disabled",
+            self.runout_helper.runout_distance,
+        )
+
+    def sensor_get_status(self, eventtime):
+        return {
+            "runout_distance": float(self.runout_helper.runout_distance),
+            "runout_elapsed": float(self.runout_helper.runout_elapsed),
+        }
+
+    def get_info(self, gcmd):
+        runout_distance = gcmd.get_float("RUNOUT_DISTANCE", None, minval=0.0)
+        if runout_distance is None:
+            gcmd.respond_info(self.get_sensor_status())
+            return 1
+        return 0
+
+    def enable(self, enable):
+        if enable != self.runout_helper.sensor_enabled:
+            return 1
+        return 0
+
+    def set_filament_sensor(self, gcmd):
+        runout_distance = gcmd.get_float("RUNOUT_DISTANCE", None, minval=0.0)
+        if runout_distance is not None:
+            self.runout_helper.runout_distance = runout_distance
+        return 0
+
+    def reset(self):
+        self.runout_helper.reset_runout_distance_info()
+        self.runout_helper.note_filament_present(
+            self.runout_helper.filament_present, True
+        )
 
 
 def load_config_prefix(config):

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -248,10 +248,20 @@ class SwitchSensor:
         return extruder.find_past_position(print_time)
 
     def get_sensor_status(self):
-        return "Filament Sensor %s: %s\n" "Runout Distance: %.2f" % (
-            self.runout_helper.name,
-            "enabled" if self.runout_helper.sensor_enabled else "disabled",
-            self.runout_helper.runout_distance,
+        return (
+            "Filament Sensor %s: %s\n"
+            "Filament Detected: %s\n"
+            "Runout Distance: %.2f\n"
+            "Runout Elapsed: %.2f\n"
+            "Smart: %s"
+            % (
+                self.runout_helper.name,
+                "enabled" if self.runout_helper.sensor_enabled else "disabled",
+                "true" if self.runout_helper.filament_present else "false",
+                self.runout_helper.runout_distance,
+                self.runout_helper.runout_elapsed,
+                "true" if self.runout_helper.smart else "false",
+            )
         )
 
     def sensor_get_status(self, eventtime):
@@ -276,6 +286,8 @@ class SwitchSensor:
         runout_distance = gcmd.get_float("RUNOUT_DISTANCE", None, minval=0.0)
         if runout_distance is not None:
             self.runout_helper.runout_distance = runout_distance
+        # No reset is needed when changing the runout_distance, so we always
+        # return False
         return False
 
     def reset(self):


### PR DESCRIPTION
Added a runout_distance parameter to filament switch sensors which means that after a filament_switch sensor triggers the printer will print for another `x` mm of filament (if your sensor sits at the end of a reverse bowden tube)

Filament sensor parameters can now be set via command (If you run a reverse bowden between motion sensor and extruder and retract after a print, there will be a buffer in the bowden which means you intially need a higher detection length than you would need while printint, now you can adjust it on the fly)

Added smart parameter to the sensors:
normally the sensor class uses the idle_timeout sttatus to determine whether the printer is printing, which also tiggers of you just move the toolhead (leading to false positives)
if smart is set to 1, it will use the virtual_sd_card module to determine the state, leading to no false positives but making the sensor not trigger when printing via usb stream

(Of course there are mainsail UI changes for this as well, which I will happily provide if requested :))
