### PR TITLE
fix homing error with dockable_probe and safe_z_home

### DIFF
--- a/klippy/extras/dockable_probe.py
+++ b/klippy/extras/dockable_probe.py
@@ -583,10 +583,9 @@ class DockableProbe:
 
     # Align z axis to prevent crashes
     def _align_z(self):
-        if not self._last_homed:
-            curtime = self.printer.get_reactor().monotonic()
-            homed_axes = self.toolhead.get_status(curtime)["homed_axes"]
-            self._last_homed = homed_axes
+        curtime = self.printer.get_reactor().monotonic()
+        homed_axes = self.toolhead.get_status(curtime)["homed_axes"]
+        self._last_homed = homed_axes
 
         if self.dock_requires_z:
             self._align_z_required()


### PR DESCRIPTION
Looks like DK is missing commit [ce73f72](https://github.com/cloakedcode/klipper/commit/ce73f72cab30035b3fb269822fd515bf79a03fff) from its copy of `dockable_probe.py`. This causes a breakage when homing with a dockable_probe + virtual z endstop + safe_z_home. When homing z, I get this error:

```
Must home axis first: 125.000 125.000 20.705 [0.000]
```

The same happens with the hacky z-hop I had in my own [homing_override](https://github.com/timwu/trident_configs/blob/main/sensorless-homing.cfg#L18-L54).

Merging in the commit seems to fix my issue with `safe_z_home` and my `homing_override`.