### PR TITLE
Fix behavior of z_calibration with dockable_probe

### DIFF
--- a/klippy/extras/z_calibration.py
+++ b/klippy/extras/z_calibration.py
@@ -523,7 +523,7 @@ class CalibrationState:
         )
         # probe the probe-switch
         self.helper.switch_gcode.run_gcode_from_command()
-        self.probe.multi_probe.begin()
+        self.probe.multi_probe_begin()
         # probe the body of the switch
         switch_zero = self._probe_on_site(
             self.z_endstop, self.helper.switch_site, check_probe=True

--- a/klippy/extras/z_calibration.py
+++ b/klippy/extras/z_calibration.py
@@ -513,6 +513,7 @@ class CalibrationState:
 
     def calibrate_z(self):
         self.helper.start_gcode.run_gcode_from_command()
+        self.probe.multi_probe.begin()
         # probe the nozzle
         nozzle_zero = self._probe_on_site(
             self.z_endstop,
@@ -532,6 +533,7 @@ class CalibrationState:
         probe_zero = self._probe_on_site(
             self.probe.mcu_probe, probe_site, check_probe=True
         )
+        self.probe.multi_probe_end()
         # calculate the offset
         offset = probe_zero - (
             switch_zero - nozzle_zero + self.helper.switch_offset

--- a/klippy/extras/z_calibration.py
+++ b/klippy/extras/z_calibration.py
@@ -513,7 +513,6 @@ class CalibrationState:
 
     def calibrate_z(self):
         self.helper.start_gcode.run_gcode_from_command()
-        self.probe.multi_probe.begin()
         # probe the nozzle
         nozzle_zero = self._probe_on_site(
             self.z_endstop,
@@ -524,6 +523,7 @@ class CalibrationState:
         )
         # probe the probe-switch
         self.helper.switch_gcode.run_gcode_from_command()
+        self.probe.multi_probe.begin()
         # probe the body of the switch
         switch_zero = self._probe_on_site(
             self.z_endstop, self.helper.switch_site, check_probe=True


### PR DESCRIPTION
With dockable_probe, when auto_attach_detach == true, the probe is detached during Calibrate_Z after first probe

Adding multi_probe_begin() / multi_probe_end(), no need to configure start_gode, end_gcode with dockable_probe if auto_attach_detach is true.