### PR TITLE
Some improvements to dockable_probe

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2218,12 +2218,28 @@ detach_position: 0,0,0
 #   If Z is specified the toolhead will move to the Z location before the X, Y
 #   coordinates.
 #   This parameter is required.
+#extract_position: 0,0,0
+#   Similar to the approach_position, the extract_position is the coordinates
+#   where the toolhead is moved to extract the probe from the dock.
+#   If Z is specified the toolhead will move to the Z location before the X, Y
+#   coordinates.
+#   The default value is approach_probe value.
+#insert_position: 0,0,0
+#   Similar to the extract_position, the insert_position is the coordinates
+#   where the toolhead is moved before inserting the probe into the dock.
+#   If Z is specified the toolhead will move to the Z location before the X, Y
+#   coordinates.
+#   The default value is extract_probe value.
 #z_hop: 15.0
 #   Distance (in mm) to lift the Z axis prior to attaching/detaching the probe.
 #   If the Z axis is already homed and the current Z position is less
 #   than `z_hop`, then this will lift the head to a height of `z_hop`. If
 #   the Z axis is not already homed the head is lifted by `z_hop`.
 #   The default is to not implement Z hop.
+#restore_toolhead: True
+#   While True, the position of the toolhead is restored to the position prior 
+#   to the attach/detach movements.
+#   The default value is True.
 #dock_retries:
 #   The number of times to attempt to attach/dock the probe before raising
 #   an error and aborting probing.

--- a/docs/Dockable_Probe.md
+++ b/docs/Dockable_Probe.md
@@ -73,6 +73,16 @@ detach_position:
   away from the probe dock such that the magnets on the probe body are not
   attracted to the magnets on the toolhead.
 
+- `extract_position: 295, 250, 0`\
+  _Default Value: approach\_position_\
+  Euclid probe requires the toolhead to move to a different direction to extract
+  or dock mag_probe.
+
+- `insert_position: 295, 250, 0`\
+  _Default Value: extract\_position_\
+  Usually the same as extract position for Euclid probe when the dock is on the
+  gantry.
+
 - `z_hop: 15.0`\
   _Default Value: None_\
   Distance (in mm) to lift the Z axis prior to attaching/detaching the probe.
@@ -80,6 +90,11 @@ detach_position:
   than `z_hop`, then this will lift the head to a height of `z_hop`. If
   the Z axis is not already homed the head is lifted by `z_hop`.
   The default is to not implement Z hop.
+
+- `restore_toolhead: False|True`\
+  _Default Value: True_\
+  While True, the position of the toolhead is restored to the position prior to 
+  the attach/detach movements.
 
 ## Position Examples
 
@@ -145,9 +160,7 @@ z_hop: 15
 Euclid style probe that requires the attach and detach movements to happen in
 opposite order. Attach: approach, move to dock, extract. Detach: move to
 extract position, move to dock, move to approach position. The approach and
-detach positions are the same, as are the extract and insert positions. The
-movements can be reordered as necessary by overriding the commands for
-extract/insert and using the same coordinates for approach and detach.
+detach positions are the same, as are the extract and insert positions.
 
 ```
 Attach:
@@ -167,18 +180,9 @@ Detach:
 ```
 approach_position: 50, 150
 dock_position: 10, 150
+extract_position: 10, 130
 detach_position: 50, 150
 z_hop: 15
-```
-
-```
-[gcode_macro MOVE_TO_EXTRACT_PROBE]
-gcode:
-    G1 X10 Y130
-
-[gcode_macro MOVE_TO_INSERT_PROBE]
-gcode:
-    G1 X10 Y130
 ```
 
 ### Homing
@@ -294,13 +298,11 @@ This command will move the toolhead to the `dock_position`.
 
 `MOVE_TO_EXTRACT_PROBE`
 
-This command will move the toolhead away from the dock after attaching the probe.
-By default it's an alias for `MOVE_TO_APPROACH_PROBE`.
+This command will move the toolhead to the `extract_position`.
 
 `MOVE_TO_INSERT_PROBE`
 
-This command will move the toolhead near the dock before detaching the probe.
-By default it's an alias for `MOVE_TO_APPROACH_PROBE`.
+This command will move the toolhead to the `insert_position`.
 
 `MOVE_TO_DETACH_PROBE`
 

--- a/klippy/extras/dockable_probe.py
+++ b/klippy/extras/dockable_probe.py
@@ -167,6 +167,7 @@ class DockableProbe:
         self.lift_speed = config.getfloat("lift_speed", self.speed, above=0.0)
         self.dock_retries = config.getint("dock_retries", 0)
         self.auto_attach_detach = config.getboolean("auto_attach_detach", True)
+        self.restore_toolhead = config.getboolean("restore_toolhead", True)
         self.travel_speed = config.getfloat(
             "travel_speed", self.speed, above=0.0
         )
@@ -183,6 +184,8 @@ class DockableProbe:
         # Positions (approach, detach, etc)
         self.approach_position = self._parse_coord(config, "approach_position")
         self.detach_position = self._parse_coord(config, "detach_position")
+        self.extract_position = self._parse_coord(config, "extract_position", self.approach_position)
+        self.insert_position = self._parse_coord(config, "insert_position", self.extract_position)
         self.dock_position = self._parse_coord(config, "dock_position")
         self.z_hop = config.getfloat("z_hop", 0.0, above=0.0)
 
@@ -195,7 +198,7 @@ class DockableProbe:
             self.dock_position, self.approach_position
         )
         self.detach_angle, self.detach_distance = self._get_vector(
-            self.dock_position, self.detach_position
+            self.dock_position, self.insert_position
         )
 
         # Pins
@@ -290,11 +293,14 @@ class DockableProbe:
     # and return a list of numbers.
     #
     # e.g. "233, 10, 0" -> [233, 10, 0]
-    def _parse_coord(self, config, name, expected_dims=3):
-        val = config.get(name)
+    def _parse_coord(self, config, name, default=None, expected_dims=3):
+        if default:
+            val = config.get(name, None)
+        else:
+            val = config.get(name)
         error_msg = "Unable to parse {0} in {1}: {2}"
         if not val:
-            return None
+            return default
         try:
             vals = [float(x.strip()) for x in val.split(",")]
         except Exception as e:
@@ -338,6 +344,7 @@ class DockableProbe:
         # Use last_'status' here to be consistent with QUERY_PROBE_'STATUS'.
         return {
             "last_status": self.last_probe_state,
+            "auto_attach_detach": self.auto_attach_detach,
         }
 
     cmd_MOVE_TO_APPROACH_PROBE_help = (
@@ -382,14 +389,35 @@ class DockableProbe:
     )
 
     def cmd_MOVE_TO_EXTRACT_PROBE(self, gcmd):
-        self.cmd_MOVE_TO_APPROACH_PROBE(gcmd)
+        if len(self.extract_position) > 2:
+            self.toolhead.manual_move(
+                [None, None, self.extract_position[2]], self.attach_speed
+            )
+
+        self.toolhead.manual_move(
+            [self.extract_position[0], self.extract_position[1], None],
+            self.attach_speed,
+        )
 
     cmd_MOVE_TO_INSERT_PROBE_help = (
         "Move near the dock with the" "probe attached before detaching"
     )
 
     def cmd_MOVE_TO_INSERT_PROBE(self, gcmd):
-        self.cmd_MOVE_TO_APPROACH_PROBE(gcmd)
+        if self._check_distance(dist=self.detach_distance):
+            self._align_to_vector(self.detach_angle)
+        else:
+            self._move_to_vector(self.detach_angle)
+
+        if len(self.insert_position) > 2:
+            self.toolhead.manual_move(
+                [None, None, self.insert_position[2]], self.travel_speed
+            )
+
+        self.toolhead.manual_move(
+            [self.insert_position[0], self.insert_position[1], None],
+            self.travel_speed,
+        )
 
     cmd_MOVE_TO_DETACH_PROBE_help = (
         "Move away from the dock to detach" "the probe"
@@ -461,7 +489,7 @@ class DockableProbe:
         if self.get_probe_state() != PROBE_ATTACHED:
             raise self.printer.command_error("Probe attach failed!")
 
-        if return_pos:
+        if return_pos and self.restore_toolhead:
             if not self._check_distance(return_pos, self.approach_distance):
                 self.toolhead.manual_move(
                     [return_pos[0], return_pos[1], None], self.travel_speed
@@ -492,7 +520,7 @@ class DockableProbe:
         if self.get_probe_state() != PROBE_DOCKED:
             raise self.printer.command_error("Probe detach failed!")
 
-        if return_pos:
+        if return_pos and self.restore_toolhead:
             if not self._check_distance(return_pos, self.detach_distance):
                 self.toolhead.manual_move(
                     [return_pos[0], return_pos[1], None], self.travel_speed

--- a/klippy/extras/dockable_probe.py
+++ b/klippy/extras/dockable_probe.py
@@ -31,6 +31,7 @@ At least one of the following must be specified:
 Please see {0}.md and config_Reference.md.
 """
 
+
 # Helper class to handle polling pins for probe attachment states
 class PinPollingHelper:
     def __init__(self, config, endstop):
@@ -184,8 +185,12 @@ class DockableProbe:
         # Positions (approach, detach, etc)
         self.approach_position = self._parse_coord(config, "approach_position")
         self.detach_position = self._parse_coord(config, "detach_position")
-        self.extract_position = self._parse_coord(config, "extract_position", self.approach_position)
-        self.insert_position = self._parse_coord(config, "insert_position", self.extract_position)
+        self.extract_position = self._parse_coord(
+            config, "extract_position", self.approach_position
+        )
+        self.insert_position = self._parse_coord(
+            config, "insert_position", self.extract_position
+        )
         self.dock_position = self._parse_coord(config, "dock_position")
         self.z_hop = config.getfloat("z_hop", 0.0, above=0.0)
 

--- a/test/klippy/dockable_probe.cfg
+++ b/test/klippy/dockable_probe.cfg
@@ -75,6 +75,9 @@ max_z_accel: 100
 dock_position: 100, 100
 approach_position: 150, 150
 detach_position: 120, 120
+extract_position: 140, 140
+insert_position: 130, 130
 pin: PH6
 z_offset: 1.15
 check_open_attach: false
+restore_toolhead: true


### PR DESCRIPTION
Just adding some improvements to dockable_probe:
- `restore_toolhead` : if true move back to the position prior attach/detach, if false : no moves.
- `extract_position` , `insert_position` : optional positions for Euclid style probes, no need command overrides
- expose `auto_attach_detach` value

I did my best with py format and doc. :/

I just tested with Euclid and klicky on a 2.4, probably need more feedbacks 