### PR TITLE
Makes BGFLUSH_EXTRA_TIME configurable

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -119,6 +119,10 @@ A collection of DangerKlipper-specific system options
 #   When set to true, SAVE_CONFIG will recursively read [include ...] blocks
 #   for conflicts to autosave data. Any configurations updated will be backed
 #   up to configs/config_backups.
+#bgflush_extra_time: 0.250
+#   This allows to set extra flush time (in seconds) Under certain conditions, 
+#   a low value will result in an error if message is not get flushed, a high value
+#   (0.250) will result in homing/probing latency. The default is 0.250
 ```
 
 ## Common kinematic settings
@@ -2193,12 +2197,28 @@ detach_position: 0,0,0
 #   If Z is specified the toolhead will move to the Z location before the X, Y
 #   coordinates.
 #   This parameter is required.
+#extract_position: 0,0,0
+#   Similar to the approach_position, the extract_position is the coordinates
+#   where the toolhead is moved to extract the probe from the dock.
+#   If Z is specified the toolhead will move to the Z location before the X, Y
+#   coordinates.
+#   The default value is approach_probe value.
+#insert_position: 0,0,0
+#   Similar to the extract_position, the insert_position is the coordinates
+#   where the toolhead is moved before inserting the probe into the dock.
+#   If Z is specified the toolhead will move to the Z location before the X, Y
+#   coordinates.
+#   The default value is extract_probe value.
 #z_hop: 15.0
 #   Distance (in mm) to lift the Z axis prior to attaching/detaching the probe.
 #   If the Z axis is already homed and the current Z position is less
 #   than `z_hop`, then this will lift the head to a height of `z_hop`. If
 #   the Z axis is not already homed the head is lifted by `z_hop`.
 #   The default is to not implement Z hop.
+#restore_toolhead: True
+#   While True, the position of the toolhead is restored to the position prior 
+#   to the attach/detach movements.
+#   The default value is True.
 #dock_retries:
 #   The number of times to attempt to attach/dock the probe before raising
 #   an error and aborting probing.

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -120,7 +120,7 @@ A collection of DangerKlipper-specific system options
 #   for conflicts to autosave data. Any configurations updated will be backed
 #   up to configs/config_backups.
 #bgflush_extra_time: 0.250
-#   This allows to set extra flush time (in seconds) Under certain conditions, 
+#   This allows to set extra flush time (in seconds). Under certain conditions, 
 #   a low value will result in an error if message is not get flushed, a high value
 #   (0.250) will result in homing/probing latency. The default is 0.250
 ```

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2197,28 +2197,12 @@ detach_position: 0,0,0
 #   If Z is specified the toolhead will move to the Z location before the X, Y
 #   coordinates.
 #   This parameter is required.
-#extract_position: 0,0,0
-#   Similar to the approach_position, the extract_position is the coordinates
-#   where the toolhead is moved to extract the probe from the dock.
-#   If Z is specified the toolhead will move to the Z location before the X, Y
-#   coordinates.
-#   The default value is approach_probe value.
-#insert_position: 0,0,0
-#   Similar to the extract_position, the insert_position is the coordinates
-#   where the toolhead is moved before inserting the probe into the dock.
-#   If Z is specified the toolhead will move to the Z location before the X, Y
-#   coordinates.
-#   The default value is extract_probe value.
 #z_hop: 15.0
 #   Distance (in mm) to lift the Z axis prior to attaching/detaching the probe.
 #   If the Z axis is already homed and the current Z position is less
 #   than `z_hop`, then this will lift the head to a height of `z_hop`. If
 #   the Z axis is not already homed the head is lifted by `z_hop`.
 #   The default is to not implement Z hop.
-#restore_toolhead: True
-#   While True, the position of the toolhead is restored to the position prior 
-#   to the attach/detach movements.
-#   The default value is True.
 #dock_retries:
 #   The number of times to attempt to attach/dock the probe before raising
 #   an error and aborting probing.

--- a/klippy/extras/danger_options.py
+++ b/klippy/extras/danger_options.py
@@ -25,6 +25,10 @@ class DangerOptions:
         self.adc_ignore_limits = config.getboolean("adc_ignore_limits", False)
         self.autosave_includes = config.getboolean("autosave_includes", False)
 
+        self.bgflush_extra_time = config.getfloat(
+            "bgflush_extra_time", 0.250, minval=0.0
+        )
+
 
 def load_config(config):
     return DangerOptions(config)

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -230,7 +230,6 @@ BUFFER_TIME_HIGH = 2.0
 BUFFER_TIME_START = 0.250
 BGFLUSH_LOW_TIME = 0.200
 BGFLUSH_BATCH_TIME = 0.200
-BGFLUSH_EXTRA_TIME = 0.250
 MIN_KIN_TIME = 0.100
 MOVE_BATCH_TIME = 0.500
 STEPCOMPRESS_FLUSH_TIME = 0.050
@@ -249,6 +248,7 @@ class DripModeEndSignal(Exception):
 class ToolHead:
     def __init__(self, config):
         self.printer = config.get_printer()
+        self.danger_options = self.printer.lookup_object("danger_options")
         self.reactor = self.printer.get_reactor()
         self.all_mcus = [
             m for n, m in self.printer.lookup_objects(module="mcu")
@@ -533,7 +533,10 @@ class ToolHead:
                     self.check_stall_time = self.print_time
             # In "NeedPrime"/"Priming" state - flush queues if needed
             while 1:
-                end_flush = self.need_flush_time + BGFLUSH_EXTRA_TIME
+                end_flush = (
+                    self.need_flush_time
+                    + self.danger_options.bgflush_extra_time
+                )
                 if self.last_flush_time >= end_flush:
                     self.do_kick_flush_timer = True
                     return self.reactor.NEVER

--- a/test/klippy/danger_options.cfg
+++ b/test/klippy/danger_options.cfg
@@ -10,6 +10,7 @@ allow_plugin_override: True
 multi_mcu_trsync_timeout: 0.05
 adc_ignore_limits: True
 autosave_includes: True
+bgflush_extra_time: 0.250
 
 [stepper_x]
 step_pin: PF0


### PR DESCRIPTION
This https://github.com/DangerKlippers/danger-klipper/commit/7a74888b43a7e640a32fd18ae69d9dbdeaf55719 adds an extra flush time 0.25s. In certain conditions it will result in homing/probing latencies. 
 Proposal to make it configurable. 