### PR TITLE
Non-critical MCUs re-work

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
 exclude = .git,.history,.github,config,docs,lib,scripts,src,test
-ignore = E401,E203,W503,C901,E501,E722,E302,E303,E306,E741,F841,W605,E721
+ignore = E401,E203,W503,C901,E501,E722,E302,E303,E306,E741,F841,W605,E721,E231
 
 max-complexity=10

--- a/klippy/extras/adxl345.py
+++ b/klippy/extras/adxl345.py
@@ -37,6 +37,7 @@ Accel_Measurement = collections.namedtuple(
     "Accel_Measurement", ("time", "accel_x", "accel_y", "accel_z")
 )
 
+
 # Helper class to obtain measurements
 class AccelQueryHelper:
     def __init__(self, printer, cconn):
@@ -192,17 +193,20 @@ class AccelCommandHelper:
     cmd_ACCELEROMETER_QUERY_help = "Query accelerometer for the current values"
 
     def cmd_ACCELEROMETER_QUERY(self, gcmd):
-        aclient = self.chip.start_internal_client()
-        self.printer.lookup_object("toolhead").dwell(1.0)
-        aclient.finish_measurements()
-        values = aclient.get_samples()
-        if not values:
-            raise gcmd.error("No accelerometer measurements found")
-        _, accel_x, accel_y, accel_z = values[-1]
-        gcmd.respond_info(
-            "accelerometer values (x, y, z): %.6f, %.6f, %.6f"
-            % (accel_x, accel_y, accel_z)
-        )
+        try:
+            aclient = self.chip.start_internal_client()
+            self.printer.lookup_object("toolhead").dwell(1.0)
+            aclient.finish_measurements()
+            values = aclient.get_samples()
+            if not values:
+                raise gcmd.error("No accelerometer measurements found")
+            _, accel_x, accel_y, accel_z = values[-1]
+            gcmd.respond_info(
+                "accelerometer values (x, y, z): %.6f, %.6f, %.6f"
+                % (accel_x, accel_y, accel_z)
+            )
+        except Exception as e:
+            raise gcmd.error("Failed to query accelerometer: %s" % (e,))
 
     cmd_ACCELEROMETER_DEBUG_READ_help = "Query register (for debugging)"
 
@@ -282,6 +286,7 @@ MIN_MSG_TIME = 0.100
 
 BYTES_PER_SAMPLE = 5
 SAMPLES_PER_BLOCK = 10
+
 
 # Printer class that controls ADXL345 chip
 class ADXL345:

--- a/klippy/extras/danger_options.py
+++ b/klippy/extras/danger_options.py
@@ -22,6 +22,9 @@ class DangerOptions:
         self.homing_elapsed_distance_tolerance = config.getfloat(
             "homing_elapsed_distance_tolerance", 0.5, minval=0.0
         )
+        self.disable_serial_reader_warnings = config.getboolean(
+            "disable_serial_reader_warnings", False
+        )
 
 
 def load_config(config):

--- a/klippy/extras/danger_options.py
+++ b/klippy/extras/danger_options.py
@@ -25,6 +25,17 @@ class DangerOptions:
         self.disable_serial_reader_warnings = config.getboolean(
             "disable_serial_reader_warnings", False
         )
+        self.disable_webhook_logging = config.getboolean(
+            "disable_webhook_logging", False
+        )
+        self.minimal_logging = config.getboolean("minimal_logging", False)
+        if self.minimal_logging:
+            self.log_statistics = False
+            self.log_config_file_at_startup = False
+            self.log_bed_mesh_at_startup = False
+            self.log_shutdown_info = False
+            self.disable_serial_reader_warnings = True
+            self.disable_webhook_logging = True
 
 
 def load_config(config):

--- a/klippy/extras/display/display.py
+++ b/klippy/extras/display/display.py
@@ -23,6 +23,7 @@ LCD_chips = {
     "hd44780_spi": hd44780_spi.hd44780_spi,
 }
 
+
 # Storage of [display_template my_template] config sections
 class DisplayTemplate:
     def __init__(self, config):
@@ -232,6 +233,10 @@ class PrinterLCD:
             raise config.error("Unknown display_data group '%s'" % (dgroup,))
         # Screen updating
         self.printer.register_event_handler("klippy:ready", self.handle_ready)
+        self.printer.register_event_handler(
+            self.lcd_chip.mcu.get_non_critical_reconnect_event_name(),
+            self.handle_reconnect,
+        )
         self.screen_update_timer = self.reactor.register_timer(
             self.screen_update_event
         )
@@ -253,6 +258,9 @@ class PrinterLCD:
 
     def get_dimensions(self):
         return self.lcd_chip.get_dimensions()
+
+    def handle_reconnect(self):
+        self.lcd_chip.init()
 
     def handle_ready(self):
         self.lcd_chip.init()

--- a/klippy/extras/display/st7920.py
+++ b/klippy/extras/display/st7920.py
@@ -260,6 +260,7 @@ class EmulatedST7920(DisplayBase):
         sw_pins = tuple([pin_params["pin"] for pin_params in sw_pin_params])
         speed = config.getint("spi_speed", 1000000, minval=100000)
         self.spi = bus.MCU_SPI(mcu, None, None, 0, speed, sw_pins)
+        self.mcu = mcu
         # create enable helper
         self.en_helper = EnableHelper(config.get("en_pin"), self.spi)
         self.en_set = False

--- a/klippy/extras/display/uc1701.py
+++ b/klippy/extras/display/uc1701.py
@@ -191,6 +191,7 @@ class ResetHelper:
 class UC1701(DisplayBase):
     def __init__(self, config):
         io = SPI4wire(config, "a0_pin")
+        self.mcu = io.spi.get_mcu()
         DisplayBase.__init__(self, io)
         self.contrast = config.getint("contrast", 40, minval=0, maxval=63)
         self.reset = ResetHelper(config.get("rst_pin", None), io.spi)
@@ -232,6 +233,7 @@ class SSD1306(DisplayBase):
         else:
             io = SPI4wire(config, "dc_pin")
             io_bus = io.spi
+        self.mcu = io_bus.get_mcu()
         self.reset = ResetHelper(config.get("reset_pin", None), io_bus)
         DisplayBase.__init__(self, io, columns, x_offset)
         self.contrast = config.getint("contrast", 239, minval=0, maxval=255)

--- a/klippy/extras/neopixel.py
+++ b/klippy/extras/neopixel.py
@@ -50,6 +50,9 @@ class PrinterNeoPixel:
         self.old_color_data = bytearray([d ^ 1 for d in self.color_data])
         # Register callbacks
         printer.register_event_handler("klippy:connect", self.send_data)
+        printer.register_event_handler(
+            self.mcu.get_non_critical_reconnect_event_name(), self.send_data
+        )
 
     def build_config(self):
         bmt = self.mcu.seconds_to_clock(BIT_MAX_TIME)

--- a/klippy/extras/temperature_mcu.py
+++ b/klippy/extras/temperature_mcu.py
@@ -48,33 +48,15 @@ class PrinterTemperatureMCU:
         self.printer.register_event_handler(
             "klippy:mcu_identify", self._mcu_identify
         )
+        self.mcu_adc.get_mcu().register_config_callback(self._build_config)
 
-    def setup_callback(self, temperature_callback):
-        self.temperature_callback = temperature_callback
-
-    def get_report_time_delta(self):
-        return REPORT_TIME
-
-    def adc_callback(self, read_time, read_value):
-        temp = self.base_temperature + read_value * self.slope
-        self.temperature_callback(read_time + SAMPLE_COUNT * SAMPLE_TIME, temp)
-
-    def setup_minmax(self, min_temp, max_temp):
-        self.min_temp = min_temp
-        self.max_temp = max_temp
-
-    def calc_adc(self, temp):
-        return (temp - self.base_temperature) / self.slope
-
-    def calc_base(self, temp, adc):
-        return temp - adc * self.slope
-
-    def _mcu_identify(self):
-        # Obtain mcu information
-        _mcu = self.mcu_adc.get_mcu()
-        self.debug_read_cmd = _mcu.lookup_query_command(
+    def _build_config(self):
+        self.debug_read_cmd = self.mcu_adc.get_mcu().lookup_query_command(
             "debug_read order=%c addr=%u", "debug_result val=%u"
         )
+
+        # Obtain mcu information
+        _mcu = self._mcu = self.mcu_adc.get_mcu()
         self.mcu_type = _mcu.get_constants().get("MCU", "")
         # Run MCU specific configuration
         cfg_funcs = [
@@ -122,6 +104,29 @@ class PrinterTemperatureMCU:
             maxval=max(adc_range),
             range_check_count=RANGE_CHECK_COUNT,
         )
+
+    def setup_callback(self, temperature_callback):
+        self.temperature_callback = temperature_callback
+
+    def get_report_time_delta(self):
+        return REPORT_TIME
+
+    def adc_callback(self, read_time, read_value):
+        temp = self.base_temperature + read_value * self.slope
+        self.temperature_callback(read_time + SAMPLE_COUNT * SAMPLE_TIME, temp)
+
+    def setup_minmax(self, min_temp, max_temp):
+        self.min_temp = min_temp
+        self.max_temp = max_temp
+
+    def calc_adc(self, temp):
+        return (temp - self.base_temperature) / self.slope
+
+    def calc_base(self, temp, adc):
+        return temp - adc * self.slope
+
+    def _mcu_identify(self):
+        pass
 
     def config_unknown(self):
         raise self.printer.config_error(

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -511,7 +511,14 @@ class TMCCommandHelper:
             )
         # Send init
         try:
-            self._init_registers()
+            if self.mcu_tmc.mcu.non_critical_disconnected:
+                logging.info(
+                    "TMC %s failed to init - non_critical_mcu: %s is disconnected!",
+                    self.name,
+                    self.mcu_tmc.mcu.get_name(),
+                )
+            else:
+                self._init_registers()
         except self.printer.command_error as e:
             logging.info("TMC %s failed to init: %s", self.name, str(e))
 

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -399,6 +399,7 @@ class MCU_TMC_SPI:
         self.name_to_reg = name_to_reg
         self.fields = fields
         self.tmc_frequency = tmc_frequency
+        self.mcu = self.tmc_spi.spi.get_mcu()
 
     def get_fields(self):
         return self.fields

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -232,6 +232,7 @@ class MCU_TMC2660_SPI:
         self.spi = bus.MCU_SPI_from_config(config, 0, default_speed=4000000)
         self.name_to_reg = name_to_reg
         self.fields = fields
+        self.mcu = self.spi.get_mcu()
 
     def get_fields(self):
         return self.fields

--- a/klippy/extras/tmc_uart.py
+++ b/klippy/extras/tmc_uart.py
@@ -62,6 +62,7 @@ class MCU_analog_mux:
 # TMC uart communication
 ######################################################################
 
+
 # Share mutexes so only one active tmc_uart command on a single mcu at
 # a time. This helps limit cpu usage on slower micro-controllers.
 class PrinterTMCUartMutexes:
@@ -84,6 +85,7 @@ def lookup_tmc_uart_mutex(mcu):
 
 TMC_BAUD_RATE = 40000
 TMC_BAUD_RATE_AVR = 9000
+
 
 # Code for sending messages on a TMC uart
 class MCU_TMC_uart_bitbang:
@@ -270,6 +272,7 @@ class MCU_TMC_uart:
         )
         self.mutex = self.mcu_uart.mutex
         self.tmc_frequency = tmc_frequency
+        self.mcu = self.mcu_uart.mcu
 
     def get_fields(self):
         return self.fields

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -751,6 +751,7 @@ class MCU:
         self._config = config
         self._printer = printer = config.get_printer()
         self.danger_options = printer.lookup_object("danger_options")
+        self.gcode = printer.lookup_object("gcode")
         self._clocksync = clocksync
         self._reactor = printer.get_reactor()
         self._name = config.get_name()
@@ -758,7 +759,9 @@ class MCU:
             self._name = self._name[4:]
         # Serial port
         wp = "mcu '%s': " % (self._name)
-        self._serial = serialhdl.SerialReader(self._reactor, warn_prefix=wp)
+        self._serial = serialhdl.SerialReader(
+            self._reactor, warn_prefix=wp, mcu=self
+        )
         self._baud = 0
         self._canbus_iface = None
         canbus_uuid = config.get("canbus_uuid", None)
@@ -813,16 +816,30 @@ class MCU:
         self._mcu_tick_awake = 0.0
 
         # noncritical mcus
-        self.non_critical_recon_timer = self._reactor.register_timer(
-            self.non_critical_recon_event
-        )
         self.is_non_critical = config.getboolean("is_non_critical", False)
-        self._non_critical_disconnected = False
-        # self.last_noncrit_recon_eventtime = None
+        if self.is_non_critical and self.get_name() == "mcu":
+            raise error("Primary MCU cannot be marked as non-critical!")
+        if self.is_non_critical:
+            self.non_critical_recon_timer = self._reactor.register_timer(
+                self.non_critical_recon_event
+            )
+            if canbus_uuid:
+                raise error("CAN MCUs can't be non-critical yet!")
+        self.non_critical_disconnected = False
+        self._non_critical_reconnect_event_name = (
+            f"danger:non_critical_mcu_{self.get_name()}:reconnected"
+        )
+        self._non_critical_disconnect_event_name = (
+            f"danger:non_critical_mcu_{self.get_name()}:disconnected"
+        )
         self.reconnect_interval = (
             config.getfloat("reconnect_interval", 2.0) + 0.12
         )  # add small change to not collide with other events
-
+        self._cached_init_state = False
+        self._oid_count_post_inits = 0
+        self._config_cmds_post_inits = []
+        self._init_cmds_post_inits = []
+        self._restart_cmds_post_inits = []
         # Register handlers
         printer.register_event_handler(
             "klippy:firmware_restart", self._firmware_restart
@@ -909,38 +926,57 @@ class MCU:
             self.estimated_print_time = dummy_estimated_print_time
 
     def handle_non_critical_disconnect(self):
-        self._non_critical_disconnected = True
+        self.non_critical_disconnected = True
         self._clocksync.disconnect()
         self._disconnect()
         self._reactor.update_timer(
             self.non_critical_recon_timer, self._reactor.NOW
         )
-        logging.info("mcu: %s disconnected", self._name)
+        self._printer.send_event(self._non_critical_disconnect_event_name)
+        self.gcode.respond_info(f"mcu: '{self._name}' disconnected!", log=True)
 
     def non_critical_recon_event(self, eventtime):
-        self.recon_mcu()
-        return eventtime + self.reconnect_interval
+        success = self.recon_mcu()
+        if success:
+            self.gcode.respond_info(
+                f"mcu: '{self._name}' reconnected!", log=True
+            )
+            return self._reactor.NEVER
+        else:
+            return eventtime + self.reconnect_interval
 
     def _send_config(self, prev_crc):
+        if not self._cached_init_state:
+            # first time config, we haven't created callback oids yet
+            # so save the oid count for state reset later
+            self._oid_count_post_inits = self._oid_count
+            self._config_cmds_post_inits = self._config_cmds.copy()
+            self._init_cmds_post_inits = self._init_cmds.copy()
+            self._restart_cmds_post_inits = self._restart_cmds.copy()
+            self._cached_init_state = True
         # Build config commands
         for cb in self._config_callbacks:
             cb()
-        self._config_cmds.insert(
+
+        local_config_cmds = self._config_cmds.copy()
+
+        local_config_cmds.insert(
             0, "allocate_oids count=%d" % (self._oid_count,)
         )
+        logging.info("config_cmds: %s", local_config_cmds)
 
         # Resolve pin names
         mcu_type = self._serial.get_msgparser().get_constant("MCU")
         ppins = self._printer.lookup_object("pins")
         pin_resolver = ppins.get_pin_resolver(self._name)
-        for cmdlist in (self._config_cmds, self._restart_cmds, self._init_cmds):
+        for cmdlist in (local_config_cmds, self._restart_cmds, self._init_cmds):
             for i, cmd in enumerate(cmdlist):
                 cmdlist[i] = pin_resolver.update_command(cmd)
                 logging.info("command: %s", cmdlist[i])
         # Calculate config CRC
-        encoded_config = "\n".join(self._config_cmds).encode()
+        encoded_config = "\n".join(local_config_cmds).encode()
         config_crc = zlib.crc32(encoded_config) & 0xFFFFFFFF
-        self.add_config_cmd("finalize_config crc=%d" % (config_crc,))
+        local_config_cmds.append("finalize_config crc=%d" % (config_crc,))
         if prev_crc is not None and config_crc != prev_crc:
             self._check_restart("CRC mismatch")
             raise error("MCU '%s' CRC does not match config" % (self._name,))
@@ -951,7 +987,7 @@ class MCU:
                 logging.info(
                     "Sending MCU '%s' printer configuration...", self._name
                 )
-                for c in self._config_cmds:
+                for c in local_config_cmds:
                     self._serial.send(c)
             else:
                 for c in self._restart_cmds:
@@ -1009,29 +1045,26 @@ class MCU:
     def recon_mcu(self):
         res = self._mcu_identify()
         if not res:
-            return
+            return False
         self.reset_to_initial_state()
+        self.non_critical_disconnected = False
         self._connect()
-        self._reactor.update_timer(
-            self.non_critical_recon_timer, self._reactor.NEVER
-        )
-        self._reactor.unregister_timer(self.non_critical_recon_timer)
-        self.last_noncrit_recon_eventtime = None
-        logging.info("mcu: %s reconnected", self._name)
+        self._printer.send_event(self._non_critical_reconnect_event_name)
+        return True
 
     def reset_to_initial_state(self):
-        self._oid_count = 0
-        self._config_cmds = []
-        self._restart_cmds = []
-        self._init_cmds = []
+        if self._cached_init_state:
+            self._oid_count = self._oid_count_post_inits
+            self._config_cmds = self._config_cmds_post_inits.copy()
+            self._init_cmds = self._init_cmds_post_inits.copy()
+            self._restart_cmds = self._restart_cmds_post_inits.copy()
         self._reserved_move_slots = 0
-        self._stepqueues = []
         self._steppersync = None
 
     def _connect(self):
-        if self._non_critical_disconnected:
-            self.non_critical_recon_timer = self._reactor.register_timer(
-                self.non_critical_recon_event,
+        if self.non_critical_disconnected:
+            self._reactor.update_timer(
+                self.non_critical_recon_timer,
                 self._reactor.NOW + self.reconnect_interval,
             )
             return
@@ -1075,15 +1108,23 @@ class MCU:
         self._printer.set_rollover_info(self._name, log_info, log=False)
 
     def _check_serial_exists(self):
-        rts = self._restart_method != "cheetah"
-        return self._serial.check_connect(self._serialport, self._baud, rts)
+
+        if self._canbus_iface is not None:
+            cbid = self._printer.lookup_object("canbus_ids")
+            nodeid = cbid.get_nodeid(self._serialport)
+            return self._serial.check_canbus_connect(
+                self._serialport, nodeid, self._canbus_iface
+            )
+        else:
+            rts = self._restart_method != "cheetah"
+            return self._serial.check_connect(self._serialport, self._baud, rts)
 
     def _mcu_identify(self):
         if self.is_non_critical and not self._check_serial_exists():
-            self._non_critical_disconnected = True
+            self.non_critical_disconnected = True
             return False
         else:
-            self._non_critical_disconnected = False
+            self.non_critical_disconnected = False
         if self.is_fileoutput():
             self._connect_file()
         else:
@@ -1183,6 +1224,12 @@ class MCU:
 
     def get_name(self):
         return self._name
+
+    def get_non_critical_reconnect_event_name(self):
+        return self._non_critical_reconnect_event_name
+
+    def get_non_critical_disconnect_event_name(self):
+        return self._non_critical_disconnect_event_name
 
     def register_response(self, cb, msg, oid=None):
         self._serial.register_response(cb, msg, oid)
@@ -1287,7 +1334,7 @@ class MCU:
     def _firmware_restart(self, force=False):
         if (
             self._is_mcu_bridge and not force
-        ) or self._non_critical_disconnected:
+        ) or self.non_critical_disconnected:
             return
         if self._restart_method == "rpi_usb":
             self._restart_rpi_usb()

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -963,7 +963,6 @@ class MCU:
         local_config_cmds.insert(
             0, "allocate_oids count=%d" % (self._oid_count,)
         )
-        logging.info("config_cmds: %s", local_config_cmds)
 
         # Resolve pin names
         mcu_type = self._serial.get_msgparser().get_constant("MCU")
@@ -972,7 +971,6 @@ class MCU:
         for cmdlist in (local_config_cmds, self._restart_cmds, self._init_cmds):
             for i, cmd in enumerate(cmdlist):
                 cmdlist[i] = pin_resolver.update_command(cmd)
-                logging.info("command: %s", cmdlist[i])
         # Calculate config CRC
         encoded_config = "\n".join(local_config_cmds).encode()
         config_crc = zlib.crc32(encoded_config) & 0xFFFFFFFF

--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -36,6 +36,9 @@ class SerialReader:
         # Sent message notification tracking
         self.last_notify_id = 0
         self.pending_notifications = {}
+        self.danger_options = self.mcu.get_printer().lookup_object(
+            "danger_options"
+        )
 
     def _bg_thread(self):
         response = self.ffi_main.new("struct pull_queue_message *")
@@ -472,7 +475,8 @@ class SerialReader:
         )
 
     def handle_default(self, params):
-        logging.warn("%sgot %s", self.warn_prefix, params)
+        if self.danger_options.disable_serial_reader_warnings:
+            logging.warn("%sgot %s", self.warn_prefix, params)
 
 
 # Class to send a query command and return the received response

--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -14,9 +14,10 @@ class error(Exception):
 
 
 class SerialReader:
-    def __init__(self, reactor, warn_prefix=""):
+    def __init__(self, reactor, warn_prefix="", mcu=None):
         self.reactor = reactor
         self.warn_prefix = warn_prefix
+        self.mcu = mcu
         # Serial port
         self.serial_dev = None
         self.msgparser = msgproto.MessageParser(warn_prefix=warn_prefix)
@@ -122,6 +123,75 @@ class SerialReader:
                 self.serialqueue, receive_window
             )
         return True
+
+    def check_canbus_connect(
+        self, canbus_uuid, canbus_nodeid, canbus_iface="can0"
+    ):
+        import can  # XXX
+
+        logging.getLogger("can").setLevel(logging.WARN)
+        txid = canbus_nodeid * 2 + 256
+        filters = [{"can_id": txid + 1, "can_mask": 0x7FF, "extended": False}]
+        # Prep for SET_NODEID command
+        try:
+            uuid = int(canbus_uuid, 16)
+        except ValueError:
+            uuid = -1
+        if uuid < 0 or uuid > 0xFFFFFFFFFFFF:
+            self._error("Invalid CAN uuid")
+
+        CANBUS_ID_ADMIN = 0x3F0
+        CMD_QUERY_UNASSIGNED = 0x00
+        RESP_NEED_NODEID = 0x20
+        filters = [
+            {
+                "can_id": CANBUS_ID_ADMIN + 1,
+                "can_mask": 0x7FF,
+                "extended": False,
+            }
+        ]
+
+        msg = can.Message(
+            arbitration_id=CANBUS_ID_ADMIN,
+            data=[CMD_QUERY_UNASSIGNED],
+            is_extended_id=False,
+        )
+        try:
+            bus = can.interface.Bus(
+                channel=canbus_iface,
+                can_filters=filters,
+                bustype="socketcan",
+            )
+            bus.send(msg)
+        except (can.CanError, os.error) as e:
+            logging.warning("%scan issue: %s", self.warn_prefix, e)
+            return False
+
+        start_time = curtime = self.reactor.monotonic()
+        while 1:
+            tdiff = start_time + 1.0 - curtime
+            if tdiff <= 0.0:
+                break
+            msg = bus.recv(tdiff)
+            curtime = self.reactor.monotonic()
+            if (
+                msg is None
+                or msg.arbitration_id != CANBUS_ID_ADMIN + 1
+                or msg.dlc < 7
+                or msg.data[0] != RESP_NEED_NODEID
+            ):
+                continue
+            found_uuid = sum(
+                [v << ((5 - i) * 8) for i, v in enumerate(msg.data[1:7])]
+            )
+            logging.info(f"found_uuid: {found_uuid}")
+            if found_uuid == uuid:
+                self.disconnect()
+                bus.close = bus.shutdown  # XXX
+                return True
+        bus.close = bus.shutdown  # XXX
+        # logging.info(f"couldn't find uuid: {uuid}")
+        return False
 
     def connect_canbus(self, canbus_uuid, canbus_nodeid, canbus_iface="can0"):
         import can  # XXX
@@ -293,8 +363,13 @@ class SerialReader:
             else:
                 self.handlers[name, oid] = callback
 
+    def _check_noncritical_disconnected(self):
+        if self.mcu is not None and self.mcu.non_critical_disconnected:
+            self._error("non-critical MCU is disconnected")
+
     # Command sending
     def raw_send(self, cmd, minclock, reqclock, cmd_queue):
+        self._check_noncritical_disconnected()
         if self.serialqueue is None:
             logging.info(
                 "%sSerial connection closed, cmd: %s",
@@ -307,6 +382,7 @@ class SerialReader:
         )
 
     def raw_send_wait_ack(self, cmd, minclock, reqclock, cmd_queue):
+        self._check_noncritical_disconnected()
         if self.serialqueue is None:
             logging.info(
                 "%sSerial connection closed, in wait ack, cmd: %s",

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -269,7 +269,7 @@ class MCU_stepper:
         self._query_mcu_position()
 
     def _query_mcu_position(self):
-        if self._mcu.is_fileoutput():
+        if self._mcu.is_fileoutput() or self._mcu.non_critical_disconnected:
             return
         params = self._get_position_cmd.send([self._oid])
         last_pos = params["pos"]


### PR DESCRIPTION
oids and config commands can/will be created either from module `__inits__` or from config callbacks. At a reconnect, the module inits will not be called again, but the config callbacks will be. 

the approach implemented here is to cache the oid_count and config / init / restart commands before we call the callbacks for the first time. this way, we know the state of the oids and command lists that we need to return to before calling the callbacks. this way, the oids and commands should all end up correct.

additionally, we emit two events for noncritical reconnect / disconnects that modules can subscribe to for handling state management across disconnects / reconnects