### PR TITLE
Add belay module

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -4901,6 +4901,41 @@ adc2:
 #   above parameters.
 ```
 
+### [belay]
+
+Belay extruder sync sensors (one may define any number of sections
+with a "belay" prefix).
+
+```
+[belay my_belay]
+extruder_type:
+#   The type of secondary extruder. Available choices are 'trad_rack'
+#   or 'extruder_stepper'. This parameter must be specified.
+extruder_stepper_name:
+#   The name of the extruder_stepper being used as the secondary
+#   extruder. Must be specified if extruder_type is set to
+#   'extruder_stepper', but should not be specified otherwise. For
+#   example, if the config section for the secondary extruder is
+#   [extruder_stepper my_extruder_stepper], this parameter's value
+#   would be 'my_extruder_stepper'.
+#multiplier_high: 1.05
+#   High multiplier to set for the secondary extruder when extruding
+#   forward and Belay is compressed or when extruding backward and
+#   Belay is expanded. The default is 1.05.
+#multiplier_low: 0.95
+#   Low multiplier to set for the secondary extruder when extruding
+#   forward and Belay is expanded or when extruding backward and
+#   Belay is compressed. The default is 0.95.
+#debug_level: 0
+#   Controls messages sent to the console. If set to 0, no messages
+#   will be sent. If set to 1, multiplier resets will be reported, and
+#   the multiplier will be reported whenever it is set in response to
+#   a switch state change. If set to 2, the behavior is the same as 1
+#   but with an additional message whenever the multiplier is set in
+#   response to detecting an extrusion direction change. The default
+#   is 0.
+```
+
 ## Board specific hardware support
 
 ### [sx1509]

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -232,6 +232,32 @@ command above for details on the additional commands available while this tool
 is active. The optional `HORIZONTAL_MOVE_Z` value overrides the
 `horizontal_move_z` option specified in the config file.
 
+### [belay]
+
+The following commands are available when a
+[belay config section](Config_Reference.md#belay) is enabled.
+
+#### QUERY_BELAY
+`QUERY_BELAY BELAY=<config_name>`: Queries the state of the belay
+specified by `BELAY`.
+
+#### BELAY_SET_MULTIPLIER
+`BELAY_SET_MULTIPLIER BELAY=<config_name> [HIGH=<multiplier_high>]
+[LOW=<multiplier_low>]`: Sets the values of multiplier_high and/or
+multiplier_low for the belay specified by `BELAY`, overriding their
+values from the corresponding
+[belay config section](Config_Reference.md#belay). Values set by this
+command will not persist across restarts.
+
+#### BELAY_SET_STEPPER
+`BELAY_SET_STEPPER BELAY=<config_name> STEPPER=<extruder_stepper_name>`: Selects
+the extruder_stepper whose multiplier will be controlled by the belay specified
+by `BELAY`. The multiplier for the previous stepper will be reset back
+to 1 before switching to the new stepper. Stepper selections made by this
+command will not persist across restarts. This command is only available if
+extruder_type is set to 'extruder_stepper' in the corresponding
+[belay config section](Config_Reference.md#belay).
+
 ### [bltouch]
 
 The following command is available when a

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -39,6 +39,15 @@ the following strings: "adjust", "fine".
 - `current_screw`: The index for the current screw being adjusted.
 - `accepted_screws`: The number of accepted screws.
 
+## belay
+
+The following information is available in
+[belay some_name](Config_Reference.md#belay) objects:
+- `printer["belay <config_name>"].last_state`: Returns True if the belay's
+  sensor is in a triggered state (indicating its slider is compressed).
+- `printer["belay <config_name>"].enabled`: Returns True if the belay is
+  currently enabled.
+
 ## configfile
 
 The following information is available in the `configfile` object

--- a/klippy/extras/belay.py
+++ b/klippy/extras/belay.py
@@ -188,9 +188,8 @@ class Belay:
         self.gcode.respond_info("belay {}: {}".format(self.name, state_info))
 
     cmd_BELAY_SET_MULTIPLIER_help = (
-        "Sets multiplier_high and/or "
-        "multiplier_low. Does not persist across "
-        "restarts."
+        "Sets multiplier_high and/or multiplier_low. Does not persist across"
+        " restarts."
     )
 
     def cmd_BELAY_SET_MULTIPLIER(self, gcmd):
@@ -202,7 +201,7 @@ class Belay:
         )
 
     cmd_BELAY_SET_STEPPER_help = (
-        "Select the extruder_stepper object to be " "controlled by the Belay"
+        "Select the extruder_stepper object to be controlled by the Belay"
     )
 
     def cmd_BELAY_SET_STEPPER(self, gcmd):

--- a/klippy/extras/belay.py
+++ b/klippy/extras/belay.py
@@ -6,46 +6,52 @@
 DIRECTION_UPDATE_INTERVAL = 0.1
 POSITION_TIME_DIFF = 0.3
 
+
 class Belay:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.reactor = self.printer.get_reactor()
 
         # initial type-specific setup
-        type_options = ['trad_rack', 'extruder_stepper']
-        self.type = config.getchoice('extruder_type',
-                                     {t: t for t in type_options})
-        if self.type == 'trad_rack':
+        type_options = ["trad_rack", "extruder_stepper"]
+        self.type = config.getchoice(
+            "extruder_type", {t: t for t in type_options}
+        )
+        if self.type == "trad_rack":
             enable_events = ["trad_rack:synced_to_extruder"]
             disable_events = ["trad_rack:unsyncing_from_extruder"]
             self.enable_initial = False
-        elif self.type == 'extruder_stepper':
-            self.extruder_stepper_name = config.get('extruder_stepper_name')
+        elif self.type == "extruder_stepper":
+            self.extruder_stepper_name = config.get("extruder_stepper_name")
             enable_events = []
             disable_events = []
             self.enable_initial = True
 
         # register event handlers
-        self.printer.register_event_handler("klippy:connect",
-                                            self.handle_connect)
+        self.printer.register_event_handler(
+            "klippy:connect", self.handle_connect
+        )
         self.printer.register_event_handler("klippy:ready", self.handle_ready)
         for event in enable_events:
             self.printer.register_event_handler(event, self.handle_enable)
         for event in disable_events:
             self.printer.register_event_handler(event, self.handle_disable)
-        
+
         # register button
-        sensor_pin = config.get('sensor_pin')
+        sensor_pin = config.get("sensor_pin")
         buttons = self.printer.load_object(config, "buttons")
         buttons.register_buttons([sensor_pin], self.sensor_callback)
 
         # read other values
         self.multiplier_high = config.getfloat(
-            'multiplier_high', default=1.05, minval=1.)
+            "multiplier_high", default=1.05, minval=1.0
+        )
         self.multiplier_low = config.getfloat(
-            'multiplier_low', default=0.95, minval=0., maxval=1.)
+            "multiplier_low", default=0.95, minval=0.0, maxval=1.0
+        )
         self.debug_level = config.getint(
-            'debug_level', default=0., minval=0., maxval=2.)
+            "debug_level", default=0.0, minval=0.0, maxval=2.0
+        )
 
         # other variables
         self.name = config.get_name().split()[1]
@@ -53,46 +59,61 @@ class Belay:
         self.last_state = False
         self.last_direction = True
         self.set_multiplier = None
-        self.enable_conditions = [lambda : not self.enabled]
-        self.disable_conditions = [lambda : self.enabled]
-        self.gcode = self.printer.lookup_object('gcode')
+        self.enable_conditions = [lambda: not self.enabled]
+        self.disable_conditions = [lambda: self.enabled]
+        self.gcode = self.printer.lookup_object("gcode")
         self.toolhead = None
         self.update_direction_timer = self.reactor.register_timer(
-            self.update_direction)
-        
+            self.update_direction
+        )
+
         # register commands
-        self.gcode.register_mux_command("QUERY_BELAY",
-            "BELAY", self.name, self.cmd_QUERY_BELAY,
-            desc=self.cmd_QUERY_BELAY_help)
-        self.gcode.register_mux_command("BELAY_SET_MULTIPLIER",
-            "BELAY", self.name, self.cmd_BELAY_SET_MULTIPLIER,
-            desc=self.cmd_BELAY_SET_MULTIPLIER_help)
-        
+        self.gcode.register_mux_command(
+            "QUERY_BELAY",
+            "BELAY",
+            self.name,
+            self.cmd_QUERY_BELAY,
+            desc=self.cmd_QUERY_BELAY_help,
+        )
+        self.gcode.register_mux_command(
+            "BELAY_SET_MULTIPLIER",
+            "BELAY",
+            self.name,
+            self.cmd_BELAY_SET_MULTIPLIER,
+            desc=self.cmd_BELAY_SET_MULTIPLIER_help,
+        )
+
         # register extruder_stepper-only commands
-        if self.type == 'extruder_stepper':
-            self.gcode.register_mux_command("BELAY_SET_STEPPER",
-                "BELAY", self.name, self.cmd_BELAY_SET_STEPPER,
-                desc=self.cmd_BELAY_SET_STEPPER_help)
-    
+        if self.type == "extruder_stepper":
+            self.gcode.register_mux_command(
+                "BELAY_SET_STEPPER",
+                "BELAY",
+                self.name,
+                self.cmd_BELAY_SET_STEPPER,
+                desc=self.cmd_BELAY_SET_STEPPER_help,
+            )
+
     def handle_connect(self):
-        self.toolhead = self.printer.lookup_object('toolhead')
+        self.toolhead = self.printer.lookup_object("toolhead")
 
         # finish type-specific setup
-        if self.type == 'trad_rack':
-            trad_rack = self.printer.lookup_object('trad_rack')
+        if self.type == "trad_rack":
+            trad_rack = self.printer.lookup_object("trad_rack")
             self.set_multiplier = trad_rack.set_fil_driver_multiplier
             self.enable_conditions.append(trad_rack.is_fil_driver_synced)
             self.disable_conditions.append(trad_rack.is_fil_driver_synced)
-        elif self.type == 'extruder_stepper':
+        elif self.type == "extruder_stepper":
             self._set_extruder_stepper(self.extruder_stepper_name)
-            
+
     def _set_extruder_stepper(self, extruder_stepper_name):
         printer_extruder_stepper = self.printer.lookup_object(
-            'extruder_stepper {}'.format(extruder_stepper_name))
+            "extruder_stepper {}".format(extruder_stepper_name)
+        )
         stepper = printer_extruder_stepper.extruder_stepper.stepper
         base_rotation_dist = stepper.get_rotation_distance()[0]
-        self.set_multiplier = lambda m : stepper.set_rotation_distance(
-            base_rotation_dist / m)
+        self.set_multiplier = lambda m: stepper.set_rotation_distance(
+            base_rotation_dist / m
+        )
 
     def handle_ready(self):
         if self.enable_initial:
@@ -111,15 +132,16 @@ class Belay:
             if not condition():
                 return
         self.reset_multiplier()
-        self.reactor.update_timer(self.update_direction_timer,
-                                  self.reactor.NEVER)
+        self.reactor.update_timer(
+            self.update_direction_timer, self.reactor.NEVER
+        )
         self.enabled = False
 
     def sensor_callback(self, eventtime, state):
         self.last_state = state
         if self.enabled:
             self.update_multiplier()
-            
+
     def update_multiplier(self, print_msg=True):
         if self.last_state == self.last_direction:
             # compressed/forward or expanded/backward
@@ -129,59 +151,68 @@ class Belay:
             multiplier = self.multiplier_low
         self.set_multiplier(multiplier)
         if (print_msg and self.debug_level >= 1) or self.debug_level >= 2:
-            self.gcode.respond_info("Set secondary extruder multiplier: %f"
-                                    % multiplier)
+            self.gcode.respond_info(
+                "Set secondary extruder multiplier: %f" % multiplier
+            )
 
     def reset_multiplier(self):
-        self.set_multiplier(1.)
+        self.set_multiplier(1.0)
         if self.debug_level >= 1:
             self.gcode.respond_info("Reset secondary extruder multiplier")
 
     def update_direction(self, eventtime):
-        mcu = self.printer.lookup_object('mcu')
+        mcu = self.printer.lookup_object("mcu")
         print_time = mcu.estimated_print_time(eventtime)
         extruder = self.toolhead.get_extruder()
         curr_pos = extruder.find_past_position(print_time)
         past_pos = extruder.find_past_position(
-            max(0., print_time - POSITION_TIME_DIFF))
+            max(0.0, print_time - POSITION_TIME_DIFF)
+        )
         prev_direction = self.last_direction
-        self.last_direction = (curr_pos >= past_pos)
+        self.last_direction = curr_pos >= past_pos
         if self.last_direction != prev_direction:
             if self.debug_level >= 2:
-                self.gcode.respond_info("New Belay sensor direction: %s"
-                                        % self.last_direction)
+                self.gcode.respond_info(
+                    "New Belay sensor direction: %s" % self.last_direction
+                )
             self.update_multiplier(False)
         return eventtime + DIRECTION_UPDATE_INTERVAL
-    
+
     cmd_QUERY_BELAY_help = "Report Belay sensor state"
+
     def cmd_QUERY_BELAY(self, gcmd):
         if self.last_state:
-            state_info = 'compressed'
+            state_info = "compressed"
         else:
-            state_info = 'expanded'
+            state_info = "expanded"
         self.gcode.respond_info("belay {}: {}".format(self.name, state_info))
 
-    cmd_BELAY_SET_MULTIPLIER_help = ("Sets multiplier_high and/or "
-                                     "multiplier_low. Does not persist across "
-                                     "restarts.")
+    cmd_BELAY_SET_MULTIPLIER_help = (
+        "Sets multiplier_high and/or "
+        "multiplier_low. Does not persist across "
+        "restarts."
+    )
+
     def cmd_BELAY_SET_MULTIPLIER(self, gcmd):
-        self.multiplier_high = gcmd.get_float('HIGH', self.multiplier_high,
-                                              minval=1.)
-        self.multiplier_low = gcmd.get_float('LOW', self.multiplier_low,
-                                            minval=0., maxval=1.)
-        
-    cmd_BELAY_SET_STEPPER_help = ("Select the extruder_stepper object to be "
-                                  "controlled by the Belay")
+        self.multiplier_high = gcmd.get_float(
+            "HIGH", self.multiplier_high, minval=1.0
+        )
+        self.multiplier_low = gcmd.get_float(
+            "LOW", self.multiplier_low, minval=0.0, maxval=1.0
+        )
+
+    cmd_BELAY_SET_STEPPER_help = (
+        "Select the extruder_stepper object to be " "controlled by the Belay"
+    )
+
     def cmd_BELAY_SET_STEPPER(self, gcmd):
         self.handle_disable()
-        self._set_extruder_stepper(gcmd.get('STEPPER'))
+        self._set_extruder_stepper(gcmd.get("STEPPER"))
         self.handle_enable()
 
     def get_status(self, eventtime):
-        return {
-            'last_state': self.last_state,
-            'enabled': self.enabled
-        }
+        return {"last_state": self.last_state, "enabled": self.enabled}
+
 
 def load_config_prefix(config):
     return Belay(config)

--- a/klippy/extras/belay.py
+++ b/klippy/extras/belay.py
@@ -1,0 +1,187 @@
+# Belay extruder-syncing sensor support
+#
+# Copyright (C) 2023-2024 Ryan Ghosh <rghosh776@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+DIRECTION_UPDATE_INTERVAL = 0.1
+POSITION_TIME_DIFF = 0.3
+
+class Belay:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.reactor = self.printer.get_reactor()
+
+        # initial type-specific setup
+        type_options = ['trad_rack', 'extruder_stepper']
+        self.type = config.getchoice('extruder_type',
+                                     {t: t for t in type_options})
+        if self.type == 'trad_rack':
+            enable_events = ["trad_rack:synced_to_extruder"]
+            disable_events = ["trad_rack:unsyncing_from_extruder"]
+            self.enable_initial = False
+        elif self.type == 'extruder_stepper':
+            self.extruder_stepper_name = config.get('extruder_stepper_name')
+            enable_events = []
+            disable_events = []
+            self.enable_initial = True
+
+        # register event handlers
+        self.printer.register_event_handler("klippy:connect",
+                                            self.handle_connect)
+        self.printer.register_event_handler("klippy:ready", self.handle_ready)
+        for event in enable_events:
+            self.printer.register_event_handler(event, self.handle_enable)
+        for event in disable_events:
+            self.printer.register_event_handler(event, self.handle_disable)
+        
+        # register button
+        sensor_pin = config.get('sensor_pin')
+        buttons = self.printer.load_object(config, "buttons")
+        buttons.register_buttons([sensor_pin], self.sensor_callback)
+
+        # read other values
+        self.multiplier_high = config.getfloat(
+            'multiplier_high', default=1.05, minval=1.)
+        self.multiplier_low = config.getfloat(
+            'multiplier_low', default=0.95, minval=0., maxval=1.)
+        self.debug_level = config.getint(
+            'debug_level', default=0., minval=0., maxval=2.)
+
+        # other variables
+        self.name = config.get_name().split()[1]
+        self.enabled = False
+        self.last_state = False
+        self.last_direction = True
+        self.set_multiplier = None
+        self.enable_conditions = [lambda : not self.enabled]
+        self.disable_conditions = [lambda : self.enabled]
+        self.gcode = self.printer.lookup_object('gcode')
+        self.toolhead = None
+        self.update_direction_timer = self.reactor.register_timer(
+            self.update_direction)
+        
+        # register commands
+        self.gcode.register_mux_command("QUERY_BELAY",
+            "BELAY", self.name, self.cmd_QUERY_BELAY,
+            desc=self.cmd_QUERY_BELAY_help)
+        self.gcode.register_mux_command("BELAY_SET_MULTIPLIER",
+            "BELAY", self.name, self.cmd_BELAY_SET_MULTIPLIER,
+            desc=self.cmd_BELAY_SET_MULTIPLIER_help)
+        
+        # register extruder_stepper-only commands
+        if self.type == 'extruder_stepper':
+            self.gcode.register_mux_command("BELAY_SET_STEPPER",
+                "BELAY", self.name, self.cmd_BELAY_SET_STEPPER,
+                desc=self.cmd_BELAY_SET_STEPPER_help)
+    
+    def handle_connect(self):
+        self.toolhead = self.printer.lookup_object('toolhead')
+
+        # finish type-specific setup
+        if self.type == 'trad_rack':
+            trad_rack = self.printer.lookup_object('trad_rack')
+            self.set_multiplier = trad_rack.set_fil_driver_multiplier
+            self.enable_conditions.append(trad_rack.is_fil_driver_synced)
+            self.disable_conditions.append(trad_rack.is_fil_driver_synced)
+        elif self.type == 'extruder_stepper':
+            self._set_extruder_stepper(self.extruder_stepper_name)
+            
+    def _set_extruder_stepper(self, extruder_stepper_name):
+        printer_extruder_stepper = self.printer.lookup_object(
+            'extruder_stepper {}'.format(extruder_stepper_name))
+        stepper = printer_extruder_stepper.extruder_stepper.stepper
+        base_rotation_dist = stepper.get_rotation_distance()[0]
+        self.set_multiplier = lambda m : stepper.set_rotation_distance(
+            base_rotation_dist / m)
+
+    def handle_ready(self):
+        if self.enable_initial:
+            self.handle_enable()
+
+    def handle_enable(self):
+        for condition in self.enable_conditions:
+            if not condition():
+                return
+        self.enabled = True
+        self.reactor.update_timer(self.update_direction_timer, self.reactor.NOW)
+        self.update_multiplier()
+
+    def handle_disable(self):
+        for condition in self.disable_conditions:
+            if not condition():
+                return
+        self.reset_multiplier()
+        self.reactor.update_timer(self.update_direction_timer,
+                                  self.reactor.NEVER)
+        self.enabled = False
+
+    def sensor_callback(self, eventtime, state):
+        self.last_state = state
+        if self.enabled:
+            self.update_multiplier()
+            
+    def update_multiplier(self, print_msg=True):
+        if self.last_state == self.last_direction:
+            # compressed/forward or expanded/backward
+            multiplier = self.multiplier_high
+        else:
+            # compressed/backward or expanded/forward
+            multiplier = self.multiplier_low
+        self.set_multiplier(multiplier)
+        if (print_msg and self.debug_level >= 1) or self.debug_level >= 2:
+            self.gcode.respond_info("Set secondary extruder multiplier: %f"
+                                    % multiplier)
+
+    def reset_multiplier(self):
+        self.set_multiplier(1.)
+        if self.debug_level >= 1:
+            self.gcode.respond_info("Reset secondary extruder multiplier")
+
+    def update_direction(self, eventtime):
+        mcu = self.printer.lookup_object('mcu')
+        print_time = mcu.estimated_print_time(eventtime)
+        extruder = self.toolhead.get_extruder()
+        curr_pos = extruder.find_past_position(print_time)
+        past_pos = extruder.find_past_position(
+            max(0., print_time - POSITION_TIME_DIFF))
+        prev_direction = self.last_direction
+        self.last_direction = (curr_pos >= past_pos)
+        if self.last_direction != prev_direction:
+            if self.debug_level >= 2:
+                self.gcode.respond_info("New Belay sensor direction: %s"
+                                        % self.last_direction)
+            self.update_multiplier(False)
+        return eventtime + DIRECTION_UPDATE_INTERVAL
+    
+    cmd_QUERY_BELAY_help = "Report Belay sensor state"
+    def cmd_QUERY_BELAY(self, gcmd):
+        if self.last_state:
+            state_info = 'compressed'
+        else:
+            state_info = 'expanded'
+        self.gcode.respond_info("belay {}: {}".format(self.name, state_info))
+
+    cmd_BELAY_SET_MULTIPLIER_help = ("Sets multiplier_high and/or "
+                                     "multiplier_low. Does not persist across "
+                                     "restarts.")
+    def cmd_BELAY_SET_MULTIPLIER(self, gcmd):
+        self.multiplier_high = gcmd.get_float('HIGH', self.multiplier_high,
+                                              minval=1.)
+        self.multiplier_low = gcmd.get_float('LOW', self.multiplier_low,
+                                            minval=0., maxval=1.)
+        
+    cmd_BELAY_SET_STEPPER_help = ("Select the extruder_stepper object to be "
+                                  "controlled by the Belay")
+    def cmd_BELAY_SET_STEPPER(self, gcmd):
+        self.handle_disable()
+        self._set_extruder_stepper(gcmd.get('STEPPER'))
+        self.handle_enable()
+
+    def get_status(self, eventtime):
+        return {
+            'last_state': self.last_state,
+            'enabled': self.enabled
+        }
+
+def load_config_prefix(config):
+    return Belay(config)


### PR DESCRIPTION
This adds the `belay` module from the [Annex Belay repo](https://github.com/Annex-Engineering/Belay) and copies related documentation into the following documents:
- Config_Reference
- G-Codes
- Status_Reference