### PR TITLE
Draft: Fan to make migration easy from ML

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3318,6 +3318,10 @@ pin:
 #   input. In such a case, the PWM pin can be used normally, and e.g. a
 #   ground-switched FET(standard fan pin) can be used to control power to
 #   the fan.
+#off_below:
+#   The minimum input speed which will power the fan (expressed as a
+#   value from 0.0 to 1.0). When a speed lower than off_below is
+#   requested the fan will instead be turned off. The default is 0.0.
 ```
 
 ### [heated_fan]

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -157,6 +157,7 @@ The following information is available in
 [controller_fan some_name](Config_Reference.md#controller_fan)
 objects:
 - `speed`: The fan speed as a float between 0.0 and 1.0.
+- `power`: The fan power as a float between 0|`min_power` and `max_power`.
 - `rpm`: The measured fan speed in rotations per minute if the fan has
   a tachometer_pin defined.
 


### PR DESCRIPTION
As discussed on discord 
There are 2 points in fan.py that make the migration not as smooth as it could be.
Both points are more to not break the UI/macros than to have a better implementation in DK.

The current PR is just to discuss how this could evolve.
- ``off_below``: in DK min_power replaces off_below. the output is scaled between ``off_below|min_power`` and ``max_power`` whereas in mainline ``off_below`` just turns off the fan when the target fan speed is below the value and the output is scaled between 0 and ``max_power``. 
IMO both settings can be retained without interference (see proposal)
- exposed ``speed``: in DK it's the target, whereas in mainline it's the pwm value. This results in a different display speed in the user interface.
Ex: a fan with max_power: 0.5, the interface displays 200% if the fan is at 100% in DK. This problem cannot be solved without modifying the user interfaces. 
2 suggested behaviors: 
- make ``speed`` equal to pwm as the main line, then ask the UIs to introduce min_power in their math.
- add the value ``power`` then ask UIs to use speed without calculation if ``power`` exists.

TY