### PR TITLE
Post homing resting position

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -254,6 +254,12 @@ position_max:
 #second_homing_speed:
 #   Velocity (in mm/s) of the stepper when performing the second home.
 #   The default is homing_speed/2.
+#post_homing_retract_dist:
+#   Distance to back off after successfully homing, the default is
+#   homing_retract_dist.
+#post_homing_retract_speed:
+#   Velocity (in mm/s) of the stepper when retracting after successfully
+#   homing, the default is homing_retract_speed
 #homing_positive_dir:
 #   If true, homing will cause the stepper to move in a positive
 #   direction (away from zero); if false, home towards zero. It is

--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -369,9 +369,10 @@ class Homing:
                     homepos = self._fill_coord(movepos)
                     axes_d = [hp - sp for hp, sp in zip(homepos, startpos)]
                     move_d = math.sqrt(sum([d * d for d in axes_d[:3]]))
-                    retract_r = min(1., hi.post_retract_dist / move_d)
-                    retractpos = [hp - ad * retract_r
-                                  for hp, ad in zip(homepos, axes_d)]
+                    retract_r = min(1.0, hi.post_retract_dist / move_d)
+                    retractpos = [
+                        hp - ad * retract_r for hp, ad in zip(homepos, axes_d)
+                    ]
                     self.toolhead.move(retractpos, hi.post_retract_speed)
         self._set_current_post_homing(homing_axes)
         # Signal home operation complete

--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -364,6 +364,15 @@ class Homing:
                         hp - ad * retract_r for hp, ad in zip(homepos, axes_d)
                     ]
                     self.toolhead.move(retractpos, hi.retract_speed)
+                if hi.post_retract_dist:
+                    startpos = self._fill_coord(forcepos)
+                    homepos = self._fill_coord(movepos)
+                    axes_d = [hp - sp for hp, sp in zip(homepos, startpos)]
+                    move_d = math.sqrt(sum([d * d for d in axes_d[:3]]))
+                    retract_r = min(1., hi.post_retract_dist / move_d)
+                    retractpos = [hp - ad * retract_r
+                                  for hp, ad in zip(homepos, axes_d)]
+                    self.toolhead.move(retractpos, hi.post_retract_speed)
         self._set_current_post_homing(homing_axes)
         # Signal home operation complete
         self.toolhead.flush_step_generation()

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -449,9 +449,11 @@ class PrinterRail:
             "homing_retract_dist", 5.0, minval=0.0
         )
         self.post_homing_retract_speed = config.getfloat(
-            'post_homing_retract_speed', self.homing_retract_speed, above=0.)
+            "post_homing_retract_speed", self.homing_retract_speed, above=0.0
+        )
         self.post_homing_retract_dist = config.getfloat(
-            'post_homing_retract_dist', self.homing_retract_dist, minval=0.)
+            "post_homing_retract_dist", self.homing_retract_dist, minval=0.0
+        )
         self.homing_positive_dir = config.getboolean(
             "homing_positive_dir", None
         )
@@ -504,8 +506,8 @@ class PrinterRail:
                 "position_endstop",
                 "retract_speed",
                 "retract_dist",
-                'post_retract_speed',
-                'post_retract_dist',
+                "post_retract_speed",
+                "post_retract_dist",
                 "positive_dir",
                 "second_homing_speed",
                 "use_sensorless_homing",

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -448,6 +448,10 @@ class PrinterRail:
         self.homing_retract_dist = config.getfloat(
             "homing_retract_dist", 5.0, minval=0.0
         )
+        self.post_homing_retract_speed = config.getfloat(
+            'post_homing_retract_speed', self.homing_retract_speed, above=0.)
+        self.post_homing_retract_dist = config.getfloat(
+            'post_homing_retract_dist', self.homing_retract_dist, minval=0.)
         self.homing_positive_dir = config.getboolean(
             "homing_positive_dir", None
         )
@@ -500,6 +504,8 @@ class PrinterRail:
                 "position_endstop",
                 "retract_speed",
                 "retract_dist",
+                'post_retract_speed',
+                'post_retract_dist',
                 "positive_dir",
                 "second_homing_speed",
                 "use_sensorless_homing",
@@ -510,6 +516,8 @@ class PrinterRail:
             self.position_endstop,
             self.homing_retract_speed,
             self.homing_retract_dist,
+            self.post_homing_retract_speed,
+            self.post_homing_retract_dist,
             self.homing_positive_dir,
             self.second_homing_speed,
             self.use_sensorless_homing,


### PR DESCRIPTION
Add option to make the toolhead back away from an endstop after homing so it doesnt sit on the endstop all day long.
Please test it with sensorless homing and report and issues you endcounter as I cant test that myself.