### PR TITLE
Danger Options interface rework + new logging flags

### DIFF
--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -4,6 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import sys, os, glob, re, time, logging, configparser, io
+from extras.danger_options import get_danger_options
 
 error = configparser.Error
 
@@ -676,8 +677,7 @@ class PrinterConfig:
             raise gcode.error(msg)
         regular_data = self._strip_duplicates(regular_data, self.autosave)
 
-        self.danger_options = self.printer.lookup_object("danger_options")
-        if self.danger_options.autosave_includes:
+        if get_danger_options().autosave_includes:
             self._save_includes(cfgname, data, set(), gcode)
 
         # NOW we're safe to check for conflicts

--- a/klippy/extras/adc_temperature.py
+++ b/klippy/extras/adc_temperature.py
@@ -5,6 +5,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, bisect
 
+from .danger_options import get_danger_options
 
 ######################################################################
 # Interface between MCU adc and heater temperature callbacks
@@ -25,9 +26,6 @@ class PrinterADCtoTemperature:
         self.mcu_adc.setup_adc_callback(REPORT_TIME, self.adc_callback)
         query_adc = config.get_printer().load_object(config, "query_adc")
         query_adc.register_adc(config.get_name(), self.mcu_adc)
-        self.danger_options = config.get_printer().lookup_object(
-            "danger_options"
-        )
 
     def setup_callback(self, temperature_callback):
         self.temperature_callback = temperature_callback
@@ -40,7 +38,7 @@ class PrinterADCtoTemperature:
         self.temperature_callback(read_time + SAMPLE_COUNT * SAMPLE_TIME, temp)
 
     def setup_minmax(self, min_temp, max_temp):
-        if self.danger_options.adc_ignore_limits:
+        if get_danger_options().adc_ignore_limits:
             danger_check_count = 0
         else:
             danger_check_count = RANGE_CHECK_COUNT

--- a/klippy/extras/adc_temperature.py
+++ b/klippy/extras/adc_temperature.py
@@ -5,7 +5,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, bisect
 
-from danger_options import get_danger_options
+from extras.danger_options import get_danger_options
 
 ######################################################################
 # Interface between MCU adc and heater temperature callbacks

--- a/klippy/extras/adc_temperature.py
+++ b/klippy/extras/adc_temperature.py
@@ -5,7 +5,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, bisect
 
-from .danger_options import get_danger_options
+from danger_options import get_danger_options
 
 ######################################################################
 # Interface between MCU adc and heater temperature callbacks

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -5,6 +5,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, math, json, collections
 from . import probe
+from .danger_options import get_danger_options
 
 PROFILE_VERSION = 1
 PROFILE_OPTIONS = {
@@ -140,7 +141,7 @@ class BedMesh:
             else:
                 config_file.warn(
                     "config",
-                    f"Selected default bed mesh profile '{self.default_mesh_name}' not found in available profiles.",
+                    f"Selected default bed mesh profile '{self.default_mesh_name}' not in available profiles.",
                     "Invalid profile name",
                 )
         # register gcodes
@@ -172,8 +173,7 @@ class BedMesh:
 
     def handle_connect(self):
         self.toolhead = self.printer.lookup_object("toolhead")
-        self.danger_options = self.printer.lookup_object("danger_options")
-        if self.danger_options.log_bed_mesh_at_startup:
+        if get_danger_options().log_bed_mesh_at_startup:
             self.bmc.print_generated_points(logging.info)
 
     def set_mesh(self, mesh):
@@ -1313,9 +1313,11 @@ class ZMesh:
         y_mult = self.y_mult
         self.mesh_matrix = [
             [
-                0.0
-                if ((i % x_mult) or (j % y_mult))
-                else z_matrix[j // y_mult][i // x_mult]
+                (
+                    0.0
+                    if ((i % x_mult) or (j % y_mult))
+                    else z_matrix[j // y_mult][i // x_mult]
+                )
                 for i in range(self.mesh_x_count)
             ]
             for j in range(self.mesh_y_count)
@@ -1375,9 +1377,11 @@ class ZMesh:
         c = self.mesh_params["tension"]
         self.mesh_matrix = [
             [
-                0.0
-                if ((i % x_mult) or (j % y_mult))
-                else z_matrix[j // y_mult][i // x_mult]
+                (
+                    0.0
+                    if ((i % x_mult) or (j % y_mult))
+                    else z_matrix[j // y_mult][i // x_mult]
+                )
                 for i in range(self.mesh_x_count)
             ]
             for j in range(self.mesh_y_count)

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -5,7 +5,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, math, json, collections
 from . import probe
-from .danger_options import get_danger_options
+from danger_options import get_danger_options
 
 PROFILE_VERSION = 1
 PROFILE_OPTIONS = {

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -5,7 +5,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, math, json, collections
 from . import probe
-from danger_options import get_danger_options
+from extras.danger_options import get_danger_options
 
 PROFILE_VERSION = 1
 PROFILE_OPTIONS = {

--- a/klippy/extras/danger_options.py
+++ b/klippy/extras/danger_options.py
@@ -52,6 +52,8 @@ DANGER_OPTIONS: DangerOptions = None
 
 def get_danger_options():
     global DANGER_OPTIONS
+    if DANGER_OPTIONS is None:
+        raise Exception("DangerOptions has not been loaded yet!")
     return DANGER_OPTIONS
 
 

--- a/klippy/extras/danger_options.py
+++ b/klippy/extras/danger_options.py
@@ -1,5 +1,6 @@
 class DangerOptions:
     def __init__(self, config):
+        self.minimal_logging = config.getboolean("minimal_logging", False)
         self.log_statistics = config.getboolean("log_statistics", True)
         self.log_config_file_at_startup = config.getboolean(
             "log_config_file_at_startup", True
@@ -8,6 +9,13 @@ class DangerOptions:
             "log_bed_mesh_at_startup", True
         )
         self.log_shutdown_info = config.getboolean("log_shutdown_info", True)
+        self.log_serial_reader_warnings = config.getboolean(
+            "log_serial_reader_warnings", True
+        )
+        self.log_startup_info = config.getboolean("log_startup_info", True)
+        self.log_webhook_method_register_messages = config.getboolean(
+            "log_webhook_method_register_messages", False
+        )
         self.error_on_unused_config_options = config.getboolean(
             "error_on_unused_config_options", True
         )
@@ -29,6 +37,25 @@ class DangerOptions:
             "bgflush_extra_time", 0.250, minval=0.0
         )
 
+        if self.minimal_logging:
+            self.log_statistics = False
+            self.log_config_file_at_startup = False
+            self.log_bed_mesh_at_startup = False
+            self.log_shutdown_info = False
+            self.log_serial_reader_warnings = False
+            self.log_startup_info = False
+            self.log_webhook_method_register_messages = False
+
+
+DANGER_OPTIONS: DangerOptions = None
+
+
+def get_danger_options():
+    global DANGER_OPTIONS
+    return DANGER_OPTIONS
+
 
 def load_config(config):
-    return DangerOptions(config)
+    global DANGER_OPTIONS
+    DANGER_OPTIONS = DangerOptions(config)
+    return DANGER_OPTIONS

--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -5,6 +5,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math
 import logging
+from .danger_options import get_danger_options
 
 HOMING_START_DELAY = 0.001
 ENDSTOP_SAMPLE_TIME = 0.000015
@@ -50,7 +51,6 @@ class HomingMove:
         self.toolhead = toolhead
         self.stepper_positions = []
         self.distance_elapsed = []
-        self.danger_options = printer.lookup_object("danger_options")
 
     def get_mcu_endstops(self):
         return [es for es, name in self.endstops]
@@ -205,7 +205,7 @@ class HomingMove:
             if i in homing_axes
         ]
         distance_tolerance = (
-            self.danger_options.homing_elapsed_distance_tolerance
+            get_danger_options().homing_elapsed_distance_tolerance
         )
         if any(
             [

--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -5,7 +5,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math
 import logging
-from danger_options import get_danger_options
+from extras.danger_options import get_danger_options
 
 HOMING_START_DELAY = 0.001
 ENDSTOP_SAMPLE_TIME = 0.000015

--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -5,7 +5,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math
 import logging
-from .danger_options import get_danger_options
+from danger_options import get_danger_options
 
 HOMING_START_DELAY = 0.001
 ENDSTOP_SAMPLE_TIME = 0.000015

--- a/klippy/extras/statistics.py
+++ b/klippy/extras/statistics.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import os, time, logging
-from .danger_options import get_danger_options
+from danger_options import get_danger_options
 
 
 class PrinterSysStats:

--- a/klippy/extras/statistics.py
+++ b/klippy/extras/statistics.py
@@ -4,6 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import os, time, logging
+from .danger_options import get_danger_options
 
 
 class PrinterSysStats:
@@ -61,7 +62,6 @@ class PrinterSysStats:
 class PrinterStats:
     def __init__(self, config):
         self.printer = config.get_printer()
-        self.danger_options = self.printer.lookup_object("danger_options")
         reactor = self.printer.get_reactor()
         self.stats_timer = reactor.register_timer(self.generate_stats)
         self.stats_cb = []
@@ -79,7 +79,7 @@ class PrinterStats:
 
     def generate_stats(self, eventtime):
         stats = [cb(eventtime) for cb in self.stats_cb]
-        if max([s[0] for s in stats]) and self.danger_options.log_statistics:
+        if max([s[0] for s in stats]) and get_danger_options().log_statistics:
             logging.info(
                 "Stats %.1f: %s", eventtime, " ".join([s[1] for s in stats])
             )

--- a/klippy/extras/statistics.py
+++ b/klippy/extras/statistics.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import os, time, logging
-from danger_options import get_danger_options
+from extras.danger_options import get_danger_options
 
 
 class PrinterSysStats:

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -8,6 +8,7 @@ import math
 import os
 import zlib
 import serialhdl, msgproto, pins, chelper, clocksync
+from extras.danger_options import get_danger_options
 
 
 class error(Exception):
@@ -312,9 +313,6 @@ class MCU_endstop:
         ffi_main, ffi_lib = chelper.get_ffi()
         self._trdispatch = ffi_main.gc(ffi_lib.trdispatch_alloc(), ffi_lib.free)
         self._trsyncs = [MCU_trsync(mcu, self._trdispatch)]
-        self.danger_options = self._mcu.get_printer().lookup_object(
-            "danger_options"
-        )
 
     def get_mcu(self):
         return self._mcu
@@ -377,7 +375,7 @@ class MCU_endstop:
         self._rest_ticks = rest_ticks
         reactor = self._mcu.get_printer().get_reactor()
         self._trigger_completion = reactor.completion()
-        expire_timeout = self.danger_options.multi_mcu_trsync_timeout
+        expire_timeout = get_danger_options().multi_mcu_trsync_timeout
         if len(self._trsyncs) == 1:
             expire_timeout = TRSYNC_SINGLE_MCU_TIMEOUT
         for i, trsync in enumerate(self._trsyncs):
@@ -707,7 +705,7 @@ class MCU:
 
     def __init__(self, config, clocksync):
         self._printer = printer = config.get_printer()
-        self.danger_options = printer.lookup_object("danger_options")
+        self.gcode = printer.lookup_object("gcode")
         self._clocksync = clocksync
         self._reactor = printer.get_reactor()
         self._name = config.get_name()
@@ -798,7 +796,7 @@ class MCU:
         if clock is not None:
             self._shutdown_clock = self.clock32_to_clock64(clock)
         self._shutdown_msg = msg = params["static_string_id"]
-        if self.danger_options.log_shutdown_info:
+        if get_danger_options().log_shutdown_info:
             logging.info(
                 "MCU '%s' %s: %s\n%s\n%s",
                 self._name,
@@ -814,7 +812,7 @@ class MCU:
         append_msgs = []
         if (
             msg.startswith("ADC out of range")
-            and not self.danger_options.adc_ignore_limits
+            and not get_danger_options.adc_ignore_limits
         ):
             pheaters = self._printer.lookup_object("heaters")
             heaters = [
@@ -1024,7 +1022,8 @@ class MCU:
                 self._clocksync.connect(self._serial)
             except serialhdl.error as e:
                 raise error(str(e))
-        logging.info(self._log_info())
+        if get_danger_options().log_startup_info:
+            logging.info(self._log_info())
         ppins = self._printer.lookup_object("pins")
         pin_resolver = ppins.get_pin_resolver(self._name)
         for cname, value in self.get_constants().items():

--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -7,6 +7,7 @@ import logging, threading, os
 import serial
 
 import msgproto, chelper, util
+from extras.danger_options import get_danger_options
 
 
 class error(Exception):
@@ -367,7 +368,8 @@ class SerialReader:
         )
 
     def handle_default(self, params):
-        logging.warn("%sgot %s", self.warn_prefix, params)
+        if get_danger_options().log_serial_reader_warnings:
+            logging.warn("%sgot %s", self.warn_prefix, params)
 
 
 # Class to send a query command and return the received response

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -6,6 +6,7 @@
 import math, logging, importlib
 import chelper
 import kinematics.extruder
+from extras.danger_options import get_danger_options
 
 # Common suffixes: _d is distance (in mm), _v is velocity (in
 #   mm/second), _v2 is velocity squared (mm^2/s^2), _t is time (in
@@ -248,7 +249,6 @@ class DripModeEndSignal(Exception):
 class ToolHead:
     def __init__(self, config):
         self.printer = config.get_printer()
-        self.danger_options = self.printer.lookup_object("danger_options")
         self.reactor = self.printer.get_reactor()
         self.all_mcus = [
             m for n, m in self.printer.lookup_objects(module="mcu")
@@ -535,7 +535,7 @@ class ToolHead:
             while 1:
                 end_flush = (
                     self.need_flush_time
-                    + self.danger_options.bgflush_extra_time
+                    + get_danger_options().bgflush_extra_time
                 )
                 if self.last_flush_time >= end_flush:
                     self.do_kick_flush_timer = True

--- a/klippy/webhooks.py
+++ b/klippy/webhooks.py
@@ -5,6 +5,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license
 import logging, socket, os, sys, errno, json, collections
 import gcode
+from extras.danger_options import get_danger_options
 
 REQUEST_LOG_SIZE = 20
 
@@ -407,10 +408,11 @@ class WebHooks:
         template = web_request.get_dict("response_template")
         method = web_request.get_str("remote_method")
         new_conn = web_request.get_client_connection()
-        logging.info(
-            "webhooks: registering remote method '%s' "
-            "for connection id: %d" % (method, id(new_conn))
-        )
+        if get_danger_options().log_webhook_method_register_messages:
+            logging.info(
+                "webhooks: registering remote method '%s' "
+                "for connection id: %d" % (method, id(new_conn))
+            )
         self._remote_methods.setdefault(method, {})[new_conn] = template
 
     def get_connection(self):


### PR DESCRIPTION
instead of using printer.lookup_object, now you can just import `get_danger_options` from `danger_options.py`