### PR TITLE
Add Dan98's positional PID algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ If I want my printer to light itself on fire, I should be able to make my printe
 
 - [heater: velocity PID](https://github.com/DangerKlippers/danger-klipper/pull/47) ([klipper#6272](https://github.com/Klipper3d/klipper/pull/6272))
 
+- [heater: positional PID](https://github.com/DangerKlippers/danger-klipper/pull/210)
+
 - [heater: PID-Profiles](https://github.com/DangerKlippers/danger-klipper/pull/162)
 
 - [heater: expose heater thermistor out of min/max](https://github.com/DangerKlippers/danger-klipper/pull/182)

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -968,9 +968,10 @@ sensor_pin:
 #   be smoothed to reduce the impact of measurement noise. The default
 #   is 1 seconds.
 control:
-#   Control algorithm (either pid, pid_v or watermark). This parameter must
+#   Control algorithm: pid, pid_p, pid_v, or watermark. This parameter must
 #   be provided. pid_v should only be used on well calibrated heaters with
-#   low to moderate noise.
+#   low to moderate noise. pid_p is a reimplementation of the positional PID
+#   algorithm used by pid. See the PID documentation for further detail.
 pid_Kp:
 pid_Ki:
 pid_Kd:

--- a/docs/PID.md
+++ b/docs/PID.md
@@ -16,7 +16,7 @@ much as possible:
 * Avoid external disturbances like drafts etc
 
 ### Choosing the right PID Algorithm
-Klipper offers two different PID algorithms: Positional and Velocity
+Danger Klipper offers two different PID algorithms: Positional and Velocity
 
 * Positional (`pid`)
     * The standard algorithm
@@ -29,8 +29,17 @@ Klipper offers two different PID algorithms: Positional and Velocity
     * More susceptible to noisy sensors
     * Might require larger smoothing time constants
 
+Additionally, Danger Klipper currently offers an additional implementation of
+the positional PID algorithm configurable with `pid_p`. This aims to correct
+some implementation errors present in the `pid` loop inherited from mainline
+Klipper. In particular, heater systems with high thermal mass, high heater
+output, and/or high sensor dead time may see improved performance with `pid_p`.
+While overall behavior will be very similar to `pid` in most cases, `pid_p` is
+currently offered as an additional optional algorithm in order to gather
+user feedback and minimize any potential disruption from an algorithm change.
+
 Refer to the [control statement](Config_Reference.md#extruder) in the
-Configuration Reference.
+Configuration Reference to select your preferred algorithm.
 
 ### Running the PID Calibration
 The PID calibration is invoked via the [PID_CALIBRATE](G-Codes.md#pid_calibrate) command.

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -130,6 +130,7 @@ class Heater:
                 "watermark": ControlBangBang,
                 "pid": ControlPID,
                 "pid_v": ControlVelocityPID,
+                "positional": ControlPositionalPID,
             }
         )
         return algos[profile["control"]](profile, self, load_clean)
@@ -274,7 +275,7 @@ class Heater:
     cmd_SET_HEATER_PID_help = "Sets a heater PID parameter"
 
     def cmd_SET_HEATER_PID(self, gcmd):
-        if not isinstance(self.control, (ControlPID, ControlVelocityPID)):
+        if not isinstance(self.control, (ControlPID, ControlVelocityPID,ControlPositionalPID)):
             raise gcmd.error("Not a PID/PID_V controlled heater")
         kp = gcmd.get_float("KP", None)
         if kp is not None:
@@ -317,7 +318,7 @@ class Heater:
                 temp_profile["max_delta"] = config_section.getfloat(
                     "max_delta", 2.0, above=0.0
                 )
-            elif control == "pid" or control == "pid_v":
+            elif control == "pid" or control == "pid_v" or control == "positional":
                 for key, (type, placeholder) in PID_PROFILE_OPTIONS.items():
                     can_be_none = (
                         key != "pid_kp" and key != "pid_ki" and key != "pid_kd"
@@ -822,6 +823,78 @@ class ControlVelocityPID:
     def get_type(self):
         return "pid_v"
 
+######################################################################
+# Positional (PID) control algo
+######################################################################
+
+class ControlPositionalPID:
+    def __init__(self, profile, heater, load_clean=False):
+        self.profile = profile
+        self.heater = heater
+        self.heater_max_power = heater.get_max_power()
+        self.Kp = profile["pid_kp"] / PID_PARAM_BASE
+        self.Ki = profile["pid_ki"] / PID_PARAM_BASE
+        self.Kd = profile["pid_kd"] / PID_PARAM_BASE
+        smooth_time = (
+            self.heater.get_smooth_time()
+            if profile["smooth_time"] is None
+            else profile["smooth_time"]
+        )
+        self.dt = heater.pwm_delay
+        self.smooth = 1. + heater.get_smooth_time() / self.dt
+        self.prev_temp = AMBIENT_TEMP
+        self.prev_err = 0.
+        self.prev_der = 0.
+        self.int_sum = 0.
+
+    def temperature_update(self, read_time, temp, target_temp):
+        # calculate the error
+        err = target_temp - temp
+        # calculate the current integral amount using the Trapezoidal rule
+        ic =  ((self.prev_err + err) / 2.) * self.dt
+        i = self.int_sum + ic
+        # calculate the current derivative using a modified moving average,
+        # and derivative on measurement, to account for derivative kick
+        # when the set point changes
+        dc = -(temp - self.prev_temp) / self.dt
+        dc = ((self.smooth - 1.) * self.prev_der + dc)/self.smooth
+        # calculate the output
+        o = self.Kp * err + self.Ki * i + self.Kd * dc
+        # calculate the saturated output
+        so = max(0., min(self.heater_max_power, o))
+
+        # update the heater
+        self.heater.set_pwm(read_time, so)
+        #update the previous values
+        self.prev_temp = temp
+        self.prev_der = dc
+        if target_temp > 0.:
+            self.prev_err = err
+            if o == so:
+                # not saturated so an update is allowed
+                self.int_sum = i
+            else:
+                # saturated, so conditionally integrate
+                if (o>0.)-(o<0.) != (ic>0.)-(ic<0.):
+                    # the signs are opposite so an update is allowed
+                    self.int_sum = i
+        else:
+            self.prev_err = 0.
+            self.int_sum = 0.
+
+    def check_busy(self, eventtime, smoothed_temp, target_temp):
+        temp_diff = target_temp - smoothed_temp
+        return (abs(temp_diff) > PID_SETTLE_DELTA
+                or abs(self.prev_der) > PID_SETTLE_SLOPE)
+   
+    def update_smooth_time(self):
+        self.smooth_time = self.heater.get_smooth_time()  # smoothing window
+
+    def get_profile(self):
+        return self.profile
+   
+    def get_type(self):
+        return 'positional'
 
 ######################################################################
 # Sensor and heater lookup

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -130,7 +130,7 @@ class Heater:
                 "watermark": ControlBangBang,
                 "pid": ControlPID,
                 "pid_v": ControlVelocityPID,
-                "positional": ControlPositionalPID,
+                "pid_p": ControlPositionalPID,
             }
         )
         return algos[profile["control"]](profile, self, load_clean)
@@ -318,7 +318,7 @@ class Heater:
                 temp_profile["max_delta"] = config_section.getfloat(
                     "max_delta", 2.0, above=0.0
                 )
-            elif control == "pid" or control == "pid_v" or control == "positional":
+            elif control == "pid" or control == "pid_v" or control == "pid_p":
                 for key, (type, placeholder) in PID_PROFILE_OPTIONS.items():
                     can_be_none = (
                         key != "pid_kp" and key != "pid_ki" and key != "pid_kd"
@@ -894,7 +894,7 @@ class ControlPositionalPID:
         return self.profile
    
     def get_type(self):
-        return 'positional'
+        return 'pid_p'
 
 ######################################################################
 # Sensor and heater lookup

--- a/test/klippy/pid_p.cfg
+++ b/test/klippy/pid_p.cfg
@@ -1,0 +1,68 @@
+# Config for extruder testing
+[stepper_x]
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PE5
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_y]
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PJ1
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_z]
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PD3
+position_endstop: 0.5
+position_max: 200
+
+[extruder]
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 33.5
+nozzle_diameter: 0.500
+filament_diameter: 3.500
+heater_pin: PB4
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK5
+control: pid_v
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 210
+
+[extruder_stepper my_extra_stepper]
+extruder: extruder
+step_pin: PH5
+dir_pin: PH6
+enable_pin: !PB5
+microsteps: 16
+rotation_distance: 28.2
+
+[mcu]
+serial: /dev/ttyACM0
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100

--- a/test/klippy/pid_p.test
+++ b/test/klippy/pid_p.test
@@ -1,0 +1,13 @@
+# Pid hot modify tests
+DICTIONARY atmega2560.dict
+CONFIG pid_p.cfg
+
+# Extrude only
+G1 E5
+G1 E-2
+G1 E7
+
+# Home and extrusion moves
+G28
+G1 X20 Y20 Z1
+G1 X25 Y25 E7.5

--- a/test/klippy/pid_v.cfg
+++ b/test/klippy/pid_v.cfg
@@ -1,0 +1,68 @@
+# Config for extruder testing
+[stepper_x]
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PE5
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_y]
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PJ1
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_z]
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PD3
+position_endstop: 0.5
+position_max: 200
+
+[extruder]
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 33.5
+nozzle_diameter: 0.500
+filament_diameter: 3.500
+heater_pin: PB4
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK5
+control: pid_v
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 210
+
+[extruder_stepper my_extra_stepper]
+extruder: extruder
+step_pin: PH5
+dir_pin: PH6
+enable_pin: !PB5
+microsteps: 16
+rotation_distance: 28.2
+
+[mcu]
+serial: /dev/ttyACM0
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100

--- a/test/klippy/pid_v.test
+++ b/test/klippy/pid_v.test
@@ -1,0 +1,13 @@
+# Pid hot modify tests
+DICTIONARY atmega2560.dict
+CONFIG pid_v.cfg
+
+# Extrude only
+G1 E5
+G1 E-2
+G1 E7
+
+# Home and extrusion moves
+G28
+G1 X20 Y20 Z1
+G1 X25 Y25 E7.5


### PR DESCRIPTION
This PR adds @Dans98 's Positional PID algorithm updated with support for PID profiles to DangerKlipper. This code was originally part of Klipper3d/klipper#5955 along with pid_v and the new calibration routine, but was removed from the subsequent PRs that were merged into DK.

This algorithm functions largely the same as the standard PID loop from mainline Klipper, but corrects a few fundamental implementation errors that cause temperature overshoot and instability on some setups. 

Because this change is high impact/risk in nature, I've implemented this as an additional ControlPositionalPID heater class instead of replacing the mainline loop outright. The core PID algorithm has nearly two years of testing behind it at this point and should be solid, but it'd probably be wise to allow an extended testing period to make sure my changes to add in PID profiles haven't caused any side effects before/if the current loop is replaced.

Users can select this algorithm by setting `control = pid_p`.
