### PR TITLE
dockable_probe: def probing_move()

### DIFF
--- a/klippy/extras/dockable_probe.py
+++ b/klippy/extras/dockable_probe.py
@@ -719,6 +719,10 @@ class DockableProbe:
     def get_position_endstop(self):
         return self.position_endstop
 
+    def probing_move(self, pos, speed):
+        phoming = self.printer.lookup_object("homing")
+        return phoming.probing_move(self, pos, speed)
+
 
 def load_config(config):
     msp = DockableProbe(config)


### PR DESCRIPTION
```
  File "/home/cime/klipper/klippy/extras/probe.py", line 157, in _probe
    epos = self.mcu_probe.probing_move(pos, speed)
AttributeError: 'DockableProbe' object has no attribute 'probing_move'
MCU 'can0' shutdown: Command request
```

due to https://github.com/DangerKlippers/danger-klipper/commit/acdf8bb1080ab829c6e8092dadf6d488aa416f77

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
