### PR TITLE
dockable_probe: fix PROBE_ACCURACY position while restore_toolhead=false

### DIFF
--- a/klippy/extras/dockable_probe.py
+++ b/klippy/extras/dockable_probe.py
@@ -673,6 +673,8 @@ class DockableProbe:
         # will complete the probing next to the dock.
         return_pos = self.toolhead.get_position()
         self.auto_attach_probe(return_pos)
+        if not self.restore_toolhead :
+            self.toolhead.manual_move(return_pos, self.travel_speed)
 
     def multi_probe_end(self):
         self.multi = MULTI_OFF

--- a/klippy/extras/dockable_probe.py
+++ b/klippy/extras/dockable_probe.py
@@ -673,7 +673,7 @@ class DockableProbe:
         # will complete the probing next to the dock.
         return_pos = self.toolhead.get_position()
         self.auto_attach_probe(return_pos)
-        if not self.restore_toolhead :
+        if not self.restore_toolhead:
             self.toolhead.manual_move(return_pos, self.travel_speed)
 
     def multi_probe_end(self):


### PR DESCRIPTION
While ``restore_toolhead : false``, PROBE_ACCURACY occurs at extract_position.

## Checklist

- [x] pr title makes sense
- [ ] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
