### PR TITLE
bugfix: restore run_current after sensorless homing

### DIFF
--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -281,7 +281,7 @@ class Homing:
             chs = rail.get_tmc_current_helpers()
             dwell_time = None
             for ch in chs:
-                if ch is not None and ch.needs_home_current_change():
+                if ch is not None and ch.needs_run_current_change():
                     if dwell_time is None:
                         dwell_time = ch.current_change_dwell_time
                     ch.set_current_for_normal(print_time)

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -230,6 +230,9 @@ class TMCCurrentHelper:
     def needs_home_current_change(self):
         return self._home_current != self.run_current
 
+    def needs_run_current_change(self):
+        return self._prev_current != self.run_current
+
     def set_home_current(self, new_home_current):
         self._home_current = min(MAX_CURRENT, new_home_current)
 
@@ -281,7 +284,7 @@ class TMCCurrentHelper:
 
     def set_current(self, run_current, hold_current, print_time, force=False):
         if (
-            run_current == self._prev_current
+            run_current == self.run_current
             and hold_current == self.req_hold_current
             and not force
         ):

--- a/klippy/extras/tmc2240.py
+++ b/klippy/extras/tmc2240.py
@@ -300,6 +300,9 @@ class TMC2240CurrentHelper:
     def needs_home_current_change(self):
         return self._home_current != self.run_current
 
+    def needs_run_current_change(self):
+        return self._prev_current != self.run_current
+
     def set_home_current(self, new_home_current):
         self._home_current = min(self.max_cur, new_home_current)
 
@@ -360,7 +363,7 @@ class TMC2240CurrentHelper:
 
     def set_current(self, run_current, hold_current, print_time, force=False):
         if (
-            run_current == self._prev_current
+            run_current == self.run_current
             and hold_current == self.req_hold_current
             and not force
         ):

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -150,6 +150,9 @@ class TMC2660CurrentHelper:
     def needs_home_current_change(self):
         return self._home_current != self.current
 
+    def needs_run_current_change(self):
+        return self._prev_current != self.current
+
     def set_home_current(self, new_home_current):
         self._home_current = min(MAX_CURRENT, new_home_current)
 

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -283,6 +283,9 @@ class TMC5160CurrentHelper:
     def needs_home_current_change(self):
         return self._home_current != self.run_current
 
+    def needs_run_current_change(self):
+        return self._prev_current != self.run_current
+
     def set_home_current(self, new_home_current):
         self._home_current = min(MAX_CURRENT, new_home_current)
 
@@ -338,7 +341,7 @@ class TMC5160CurrentHelper:
 
     def set_current(self, run_current, hold_current, print_time, force=False):
         if (
-            run_current == self._prev_current
+            run_current == self.run_current
             and hold_current == self.req_hold_current
             and not force
         ):


### PR DESCRIPTION
When utilizing home_current + sensorless homing the run_current is not being restored after homing was completed.

- The needs_home_current_change check will be fales because run_current at that time is equal to home_current
- The short circuit code in most drivers is triggering falsely because it's comparing the previous run current to the requested run_current and not looking at the currently set run current, thus never setting this even after switch to a `needs_run_current_change` helper in the condition.

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
