### PR TITLE
Revert "bugfix: restore run_current after sensorless homing (#233)"

### DIFF
--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -281,7 +281,7 @@ class Homing:
             chs = rail.get_tmc_current_helpers()
             dwell_time = None
             for ch in chs:
-                if ch is not None and ch.needs_run_current_change():
+                if ch is not None and ch.needs_home_current_change():
                     if dwell_time is None:
                         dwell_time = ch.current_change_dwell_time
                     ch.set_current_for_normal(print_time)

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -230,9 +230,6 @@ class TMCCurrentHelper:
     def needs_home_current_change(self):
         return self._home_current != self.run_current
 
-    def needs_run_current_change(self):
-        return self._prev_current != self.run_current
-
     def set_home_current(self, new_home_current):
         self._home_current = min(MAX_CURRENT, new_home_current)
 
@@ -284,7 +281,7 @@ class TMCCurrentHelper:
 
     def set_current(self, run_current, hold_current, print_time, force=False):
         if (
-            run_current == self.run_current
+            run_current == self._prev_current
             and hold_current == self.req_hold_current
             and not force
         ):

--- a/klippy/extras/tmc2240.py
+++ b/klippy/extras/tmc2240.py
@@ -300,9 +300,6 @@ class TMC2240CurrentHelper:
     def needs_home_current_change(self):
         return self._home_current != self.run_current
 
-    def needs_run_current_change(self):
-        return self._prev_current != self.run_current
-
     def set_home_current(self, new_home_current):
         self._home_current = min(self.max_cur, new_home_current)
 
@@ -363,7 +360,7 @@ class TMC2240CurrentHelper:
 
     def set_current(self, run_current, hold_current, print_time, force=False):
         if (
-            run_current == self.run_current
+            run_current == self._prev_current
             and hold_current == self.req_hold_current
             and not force
         ):

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -150,9 +150,6 @@ class TMC2660CurrentHelper:
     def needs_home_current_change(self):
         return self._home_current != self.current
 
-    def needs_run_current_change(self):
-        return self._prev_current != self.current
-
     def set_home_current(self, new_home_current):
         self._home_current = min(MAX_CURRENT, new_home_current)
 

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -283,9 +283,6 @@ class TMC5160CurrentHelper:
     def needs_home_current_change(self):
         return self._home_current != self.run_current
 
-    def needs_run_current_change(self):
-        return self._prev_current != self.run_current
-
     def set_home_current(self, new_home_current):
         self._home_current = min(MAX_CURRENT, new_home_current)
 
@@ -341,7 +338,7 @@ class TMC5160CurrentHelper:
 
     def set_current(self, run_current, hold_current, print_time, force=False):
         if (
-            run_current == self.run_current
+            run_current == self._prev_current
             and hold_current == self.req_hold_current
             and not force
         ):


### PR DESCRIPTION
This reverts commit a47811645e1ead5317c00c9f7bd38ae4307ea78e.

_Enter a good description of whats being changed and WHY

## Checklist

- [ ] pr title makes sense
- [ ] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
