### PR TITLE
bugfix sensorless not returning to run_current after homing

### DIFF
--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -281,7 +281,7 @@ class Homing:
             chs = rail.get_tmc_current_helpers()
             dwell_time = None
             for ch in chs:
-                if ch is not None and ch.needs_home_current_change():
+                if ch is not None and ch.needs_run_current_change():
                     if dwell_time is None:
                         dwell_time = ch.current_change_dwell_time
                     ch.set_current_for_normal(print_time)
@@ -313,7 +313,7 @@ class Homing:
 
         # Perform second home
         if retract_dist:
-            logging.info("homing:needs rehome: %s", needs_rehome)
+            logging.info("homing: needs rehome: %s", needs_rehome)
             # Retract
             startpos = self._fill_coord(forcepos)
             homepos = self._fill_coord(movepos)

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -368,12 +368,17 @@ class TMCCommandHelper:
             or hold_current is not None
             or home_current is not None
         ):
-            if run_current is None:
+            if run_current is not None:
+                ch.set_run_current(run_current)
+            else:
                 run_current = prev_cur
+
             if hold_current is None:
                 hold_current = req_hold_cur
+
             if home_current is not None:
                 ch.set_home_current(home_current)
+
             toolhead = self.printer.lookup_object("toolhead")
             print_time = toolhead.get_last_move_time()
             ch.set_current(run_current, hold_current, print_time)
@@ -744,3 +749,103 @@ def TMCStealthchopHelper(config, mcu_tmc, tmc_freq):
     else:
         # TMC2208 uses en_spreadCycle
         fields.set_field("en_spreadcycle", not en_pwm_mode)
+
+
+class BaseTMCCurrentHelper:
+    def __init__(self, config, mcu_tmc, max_current):
+        self.printer = config.get_printer()
+        self.name = config.get_name().split()[-1]
+        self.mcu_tmc = mcu_tmc
+        self.fields = mcu_tmc.get_fields()
+
+        # config_{run|hold|home}_current
+        # represents an initial value set via config file
+        self.config_run_current = config.getfloat(
+            "run_current", above=0.0, maxval=max_current
+        )
+        self.config_hold_current = config.getfloat(
+            "hold_current", max_current, above=0.0, maxval=max_current
+        )
+        self.config_home_current = config.getfloat(
+            "home_current",
+            self.config_run_current,
+            above=0.0,
+            maxval=max_current,
+        )
+        self.current_change_dwell_time = config.getfloat(
+            "current_change_dwell_time", 0.5, above=0.0
+        )
+
+        # req_{run|hold|home}_current
+        # represents a requested value, which starts with
+        # the configured value but can change during runtime
+        # e.g. SET_TMC_CURRENT
+        self.req_run_current = self.config_run_current
+        self.req_hold_current = self.config_hold_current
+        self.req_home_current = self.config_home_current
+
+        # actual_current represents the actual current set to a stepper
+        # It fluctuates between req_run_current and req_home_current
+        # during homing
+        self.actual_current = self.req_run_current
+
+        self.max_current = max_current
+
+    def needs_home_current_change(self):
+        needs = self.actual_current != self.req_home_current
+        logging.info(f"tmc {self.name}: needs_home_current_change {needs}")
+        return needs
+
+    def needs_run_current_change(self):
+        needs = self.actual_current != self.req_run_current
+        logging.info(f"tmc {self.name}: needs_run_current_change {needs}")
+        return needs
+
+    def needs_hold_current_change(self, hold_current):
+        needs = hold_current != self.req_run_current
+        logging.info(f"tmc {self.name}: needs_hold_current_change {needs}")
+        return needs
+
+    def set_home_current(self, new_home_current):
+        self.req_home_current = min(self.max_current, new_home_current)
+
+    def set_run_current(self, new_run_current):
+        self.req_run_current = min(self.max_current, new_run_current)
+
+    def set_hold_current(self, new_hold_current):
+        self.req_hold_current = new_hold_current
+
+    def set_actual_current(self, current):
+        self.actual_current = current
+        logging.info(
+            f"tmc {self.name}: set_actual_current() new actual_current: {self.actual_current}"
+        )
+
+    def set_current_for_homing(self, print_time):
+        self.set_current(
+            self.req_home_current, self.req_hold_current, print_time
+        )
+
+    def set_current_for_normal(self, print_time):
+        self.set_current(
+            self.req_run_current, self.req_hold_current, print_time
+        )
+
+    def needs_current_changes(self, run_current, hold_current, force=False):
+        if (
+            run_current == self.actual_current
+            and hold_current == self.req_hold_current
+            and not force
+        ):
+            return False
+        return True
+
+    def set_current(self, new_current, hold_current, print_time, force=False):
+        if not self.needs_current_changes(new_current, hold_current, force):
+            return
+
+        if self.needs_hold_current_change(hold_current):
+            self.set_hold_current(hold_current)
+
+        self.set_actual_current(new_current)
+        self.apply_current(print_time)

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -197,41 +197,19 @@ FieldFormatters = {
 MAX_CURRENT = 2.000
 
 
-class TMCCurrentHelper:
+class TMC2130CurrentHelper(tmc.BaseTMCCurrentHelper):
     def __init__(self, config, mcu_tmc):
-        self.printer = config.get_printer()
-        self.name = config.get_name().split()[-1]
-        self.mcu_tmc = mcu_tmc
-        self.fields = mcu_tmc.get_fields()
-        self.run_current = config.getfloat(
-            "run_current", above=0.0, maxval=MAX_CURRENT
-        )
-        self.hold_current = config.getfloat(
-            "hold_current", MAX_CURRENT, above=0.0, maxval=MAX_CURRENT
-        )
-        self._home_current = config.getfloat(
-            "home_current", self.run_current, above=0.0, maxval=MAX_CURRENT
-        )
-        self.current_change_dwell_time = config.getfloat(
-            "current_change_dwell_time", 0.5, above=0.0
-        )
-        self._prev_current = self.run_current
-        self.req_hold_current = self.hold_current
+        super().__init__(config, mcu_tmc, MAX_CURRENT)
+
         self.sense_resistor = config.getfloat(
             "sense_resistor", 0.110, above=0.0
         )
         vsense, irun, ihold = self._calc_current(
-            self.run_current, self.hold_current
+            self.req_run_current, self.req_hold_current
         )
         self.fields.set_field("vsense", vsense)
         self.fields.set_field("ihold", ihold)
         self.fields.set_field("irun", irun)
-
-    def needs_home_current_change(self):
-        return self._home_current != self.run_current
-
-    def set_home_current(self, new_home_current):
-        self._home_current = min(MAX_CURRENT, new_home_current)
 
     def _calc_current_bits(self, current, vsense):
         sense_resistor = self.sense_resistor + 0.020
@@ -276,32 +254,19 @@ class TMCCurrentHelper:
             hold_current,
             self.req_hold_current,
             MAX_CURRENT,
-            self._home_current,
+            self.req_home_current,
         )
 
-    def set_current(self, run_current, hold_current, print_time, force=False):
-        if (
-            run_current == self._prev_current
-            and hold_current == self.req_hold_current
-            and not force
-        ):
-            return
-        self.req_hold_current = hold_current
-        vsense, irun, ihold = self._calc_current(run_current, hold_current)
+    def apply_current(self, print_time):
+        vsense, irun, ihold = self._calc_current(
+            self.actual_current, self.req_hold_current
+        )
         if vsense != self.fields.get_field("vsense"):
             val = self.fields.set_field("vsense", vsense)
             self.mcu_tmc.set_register("CHOPCONF", val, print_time)
         self.fields.set_field("ihold", ihold)
         val = self.fields.set_field("irun", irun)
         self.mcu_tmc.set_register("IHOLD_IRUN", val, print_time)
-
-    def set_current_for_homing(self, print_time):
-        prev_run_cur, _, _, _, _ = self.get_current()
-        self._prev_current = prev_run_cur
-        self.set_current(self._home_current, self.hold_current, print_time)
-
-    def set_current_for_normal(self, print_time):
-        self.set_current(self._prev_current, self.hold_current, print_time)
 
 
 ######################################################################
@@ -445,7 +410,7 @@ class TMC2130:
         # Allow virtual pins to be created
         tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
         # Register commands
-        current_helper = TMCCurrentHelper(config, self.mcu_tmc)
+        current_helper = TMC2130CurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters)
         self.get_phase_offset = cmdhelper.get_phase_offset

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -189,7 +189,7 @@ class TMC2208:
         )
         self.fields.set_field("pdn_disable", True)
         # Register commands
-        current_helper = tmc2130.TMCCurrentHelper(config, self.mcu_tmc)
+        current_helper = tmc2130.TMC2130CurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters, self.read_translate)
         self.get_phase_offset = cmdhelper.get_phase_offset

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -60,7 +60,7 @@ class TMC2209:
         # Allow virtual pins to be created
         tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
         # Register commands
-        current_helper = tmc2130.TMCCurrentHelper(config, self.mcu_tmc)
+        current_helper = tmc2130.TMC2130CurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters)
         self.get_phase_offset = cmdhelper.get_phase_offset

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -250,41 +250,19 @@ VREF = 0.325
 MAX_CURRENT = 10.000  # Maximum dependent on board, but 10 is safe sanity check
 
 
-class TMC5160CurrentHelper:
+class TMC5160CurrentHelper(tmc.BaseTMCCurrentHelper):
     def __init__(self, config, mcu_tmc):
-        self.printer = config.get_printer()
-        self.name = config.get_name().split()[-1]
-        self.mcu_tmc = mcu_tmc
-        self.fields = mcu_tmc.get_fields()
-        self.run_current = config.getfloat(
-            "run_current", above=0.0, maxval=MAX_CURRENT
-        )
-        self.hold_current = config.getfloat(
-            "hold_current", MAX_CURRENT, above=0.0, maxval=MAX_CURRENT
-        )
-        self._home_current = config.getfloat(
-            "home_current", self.run_current, above=0.0, maxval=MAX_CURRENT
-        )
-        self.current_change_dwell_time = config.getfloat(
-            "current_change_dwell_time", 0.5, above=0.0
-        )
-        self._prev_current = self.run_current
-        self.req_hold_current = self.hold_current
+        super().__init__(config, mcu_tmc, MAX_CURRENT)
+
         self.sense_resistor = config.getfloat(
             "sense_resistor", 0.075, above=0.0
         )
         gscaler, irun, ihold = self._calc_current(
-            self.run_current, self.hold_current
+            self.req_run_current, self.req_hold_current
         )
         self.fields.set_field("globalscaler", gscaler)
         self.fields.set_field("ihold", ihold)
         self.fields.set_field("irun", irun)
-
-    def needs_home_current_change(self):
-        return self._home_current != self.run_current
-
-    def set_home_current(self, new_home_current):
-        self._home_current = min(MAX_CURRENT, new_home_current)
 
     def _calc_globalscaler(self, current):
         globalscaler = int(
@@ -333,31 +311,18 @@ class TMC5160CurrentHelper:
             hold_current,
             self.req_hold_current,
             MAX_CURRENT,
-            self._home_current,
+            self.req_home_current,
         )
 
-    def set_current(self, run_current, hold_current, print_time, force=False):
-        if (
-            run_current == self._prev_current
-            and hold_current == self.req_hold_current
-            and not force
-        ):
-            return
-        self.req_hold_current = hold_current
-        gscaler, irun, ihold = self._calc_current(run_current, hold_current)
+    def apply_current(self, print_time):
+        gscaler, irun, ihold = self._calc_current(
+            self.actual_current, self.req_hold_current
+        )
         val = self.fields.set_field("globalscaler", gscaler)
         self.mcu_tmc.set_register("GLOBALSCALER", val, print_time)
         self.fields.set_field("ihold", ihold)
         val = self.fields.set_field("irun", irun)
         self.mcu_tmc.set_register("IHOLD_IRUN", val, print_time)
-
-    def set_current_for_homing(self, print_time):
-        prev_run_cur, _, _, _, _ = self.get_current()
-        self._prev_current = prev_run_cur
-        self.set_current(self._home_current, self.hold_current, print_time)
-
-    def set_current_for_normal(self, print_time):
-        self.set_current(self._prev_current, self.hold_current, print_time)
 
 
 ######################################################################


### PR DESCRIPTION
bugfix sensorless not returning to run_current after homing

I also took the opportunity to start a new BaseTMCCurrentHelper() class to reduce the duplicated code and added comments to the code to help people working on it in the future.
