### PR TITLE
docs: Add gcode_button to the Status Reference docs (#6201)

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -209,6 +209,12 @@ The following information is available in
 [gcode_button some_name](Config_Reference.md#gcode_button) objects:
 - `state`: The current button state returned as "PRESSED" or "RELEASED"
 
+## gcode_button
+
+The following information is available in
+[gcode_button some_name](Config_Reference.md#gcode_button) objects:
+- `state`: The current button state returned as "PRESSED" or "RELEASED"
+
 ## gcode_macro
 
 The following information is available in


### PR DESCRIPTION
Add gcode_button to the Status Reference docs

Klipper PR: https://github.com/Klipper3d/klipper/pull/6201