### PR TITLE
STM32 module fixes to support Stm32g474 with FDCAN (#6585)

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -88,6 +88,9 @@ choice
     config MACH_STM32G431
         bool "STM32G431"
         select MACH_STM32G4
+    config MACH_STM32G474
+        bool "STM32G474"
+        select MACH_STM32G4
     config MACH_STM32H723
         bool "STM32H723"
         select MACH_STM32H7
@@ -181,6 +184,7 @@ config MCU
     default "stm32g0b0xx" if MACH_STM32G0B0
     default "stm32g0b1xx" if MACH_STM32G0B1
     default "stm32g431xx" if MACH_STM32G431
+    default "stm32g474xx" if MACH_STM32G474
     default "stm32h723xx" if MACH_STM32H723
     default "stm32h743xx" if MACH_STM32H743
     default "stm32h750xx" if MACH_STM32H750
@@ -199,6 +203,7 @@ config CLOCK_FREQ
     default 216000000 if MACH_STM32F765
     default 64000000 if MACH_STM32G0
     default 150000000 if MACH_STM32G431
+    default 170000000 if MACH_STM32G474
     default 400000000 if MACH_STM32H7 # 400Mhz is max Klipper currently supports
     default 80000000 if MACH_STM32L412
     default 64000000 if MACH_N32G45x && STM32_CLOCK_REF_INTERNAL
@@ -213,6 +218,7 @@ config FLASH_SIZE
     default 0x40000 if MACH_STM32F2 || MACH_STM32F401 || MACH_STM32H723
     default 0x80000 if MACH_STM32F4x5 || MACH_STM32F446
     default 0x20000 if MACH_STM32G0 || MACH_STM32G431
+    default 0x40000 if MACH_STM32G474
     default 0x20000 if MACH_STM32H750
     default 0x200000 if MACH_STM32H743 || MACH_STM32F765
     default 0x20000 if MACH_N32G45x
@@ -233,6 +239,7 @@ config RAM_SIZE
     default 0x2800 if MACH_STM32F103x6
     default 0x5000 if MACH_STM32F103 && !MACH_STM32F103x6 # Ram size of stm32f103x8
     default 0x8000 if MACH_STM32G431
+    default 0x20000 if MACH_STM32G474
     default 0xa000 if MACH_STM32L412
     default 0x20000 if MACH_STM32F207
     default 0x10000 if MACH_STM32F401

--- a/src/stm32/fdcan.c
+++ b/src/stm32/fdcan.c
@@ -60,16 +60,23 @@
      || CONFIG_STM32_CANBUS_PB5_PB6 ||CONFIG_STM32_CANBUS_PB12_PB13)
  #define SOC_CAN FDCAN1
  #define MSG_RAM (((struct fdcan_ram_layout*)SRAMCAN_BASE)->fdcan1)
+ #if CONFIG_MACH_STM32H7 || CONFIG_MACH_STM32G4
+  #define CAN_IT0_IRQn  FDCAN1_IT0_IRQn
+ #endif
 #else
  #define SOC_CAN FDCAN2
  #define MSG_RAM (((struct fdcan_ram_layout*)SRAMCAN_BASE)->fdcan2)
+ #if CONFIG_MACH_STM32H7 || CONFIG_MACH_STM32G4
+  #define CAN_IT0_IRQn  FDCAN2_IT0_IRQn
+ #endif
 #endif
 
 #if CONFIG_MACH_STM32G0
  #define CAN_IT0_IRQn  TIM16_FDCAN_IT0_IRQn
  #define CAN_FUNCTION  GPIO_FUNCTION(3) // Alternative function mapping number
-#elif CONFIG_MACH_STM32H7 || CONFIG_MACH_STM32G4
- #define CAN_IT0_IRQn  FDCAN1_IT0_IRQn
+#endif
+
+#if CONFIG_MACH_STM32H7 || CONFIG_MACH_STM32G4
  #define CAN_FUNCTION  GPIO_FUNCTION(9) // Alternative function mapping number
 #endif
 

--- a/src/stm32/stm32g4.c
+++ b/src/stm32/stm32g4.c
@@ -22,6 +22,12 @@ lookup_clock_line(uint32_t periph_base)
     if (periph_base < APB2PERIPH_BASE) {
         uint32_t pos = (periph_base - APB1PERIPH_BASE) / 0x400;
         if (pos < 32) {
+#if defined(FDCAN2_BASE)
+            if (periph_base == FDCAN2_BASE)
+                return (struct cline){.en = &RCC->APB1ENR1,
+                                      .rst = &RCC->APB1RSTR1,
+                                      .bit = 1 << 25};
+#endif
             return (struct cline){.en = &RCC->APB1ENR1,
                                   .rst = &RCC->APB1RSTR1,
                                   .bit = 1 << pos};

--- a/src/stm32/stm32h7_adc.c
+++ b/src/stm32/stm32h7_adc.c
@@ -189,7 +189,11 @@ gpio_adc_setup(uint32_t pin)
     if (chan >= 2 * ADCIN_BANK_SIZE) {
         chan -= 2 * ADCIN_BANK_SIZE;
         adc = ADC3;
+#if CONFIG_MACH_STM32G4
+        adc_common = ADC345_COMMON;
+#else
         adc_common = ADC3_COMMON;
+#endif
     } else
 #endif
 #ifdef ADC2

--- a/test/configs/stm32g474.config
+++ b/test/configs/stm32g474.config
@@ -1,0 +1,3 @@
+# Base config file for STM32G474 ARM processor
+CONFIG_MACH_STM32=y
+CONFIG_MACH_STM32G474=y


### PR DESCRIPTION
stm32: Add STM32G474 chip to Kconfig
stm32: Add FDCAN2 channel needed for stm32g4 alternate pins
stm32g4: Fix ADC3 common interface registers name to ADC345_COMMON

Klipper PR: https://github.com/Klipper3d/klipper/pull/6585
