### PR TITLE
invoke danger options when checking adc ignore limits

### DIFF
--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -843,7 +843,7 @@ class MCU:
         if (
             msg.startswith("ADC out of range")
             or msg.startswith("Thermocouple reader fault")
-        ) and not get_danger_options.adc_ignore_limits:
+        ) and not get_danger_options().adc_ignore_limits:
             pheaters = self._printer.lookup_object("heaters")
             heaters = [
                 pheaters.lookup_heater(n) for n in pheaters.available_heaters


### PR DESCRIPTION
bug in mcu.py wasn't invoking `get_danger_options` function

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
