### PR TITLE
bed_mesh: Fix adaptive probe count on delta printers (#6600)

### DIFF
--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -790,9 +790,12 @@ class BedMeshCalibrate:
                 self.origin = adapted_origin
                 self.mesh_min = (-self.radius, -self.radius)
                 self.mesh_max = (self.radius, self.radius)
-                self.mesh_config["x_count"] = self.mesh_config["y_count"] = max(
-                    new_x_probe_count, new_y_probe_count
-                )
+                new_probe_count = max(new_x_probe_count, new_y_probe_count)
+                # Adaptive meshes require odd number of points
+                new_probe_count += 1 - (new_probe_count % 2)
+                self.mesh_config["x_count"] = self.mesh_config[
+                    "y_count"
+                ] = new_probe_count
         else:
             self.mesh_min = adjusted_mesh_min
             self.mesh_max = adjusted_mesh_max


### PR DESCRIPTION
Round beds require an odd number of probe points in order to prevent erroneously truncating the mesh.

The adaptive mesh algorithm did not consider that and as a result, it was possible to generate adaptive
meshes with even number of probe points.

This change fixes this by increasing the probe point count by 1 in cases where the adaptive probe points are even.

Klipper PR: https://github.com/Klipper3d/klipper/pull/6600