### PR TITLE
idex_modes: Bugfix for kinematic position calculation.

### DIFF
--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -64,7 +64,15 @@ class CartKinematics:
         return [s for rail in self.rails for s in rail.get_steppers()]
 
     def calc_position(self, stepper_positions):
-        return [stepper_positions[rail.get_name()] for rail in self.rails]
+        rails = self.rails
+        if self.dc_module:
+            primary_rail = self.dc_module.get_primary_rail().get_rail()
+            rails = (
+                rails[: self.dc_module.axis]
+                + [primary_rail]
+                + rails[self.dc_module.axis + 1 :]
+            )
+        return [stepper_positions[rail.get_name()] for rail in rails]
 
     def update_limits(self, i, range):
         l, h = self.limits[i]
@@ -73,14 +81,15 @@ class CartKinematics:
         if l <= h:
             self.limits[i] = range
 
-    def override_rail(self, i, rail):
-        self.rails[i] = rail
-
     def set_position(self, newpos, homing_axes):
         for i, rail in enumerate(self.rails):
             rail.set_position(newpos)
-            if i in homing_axes:
-                self.limits[i] = rail.get_range()
+        for axis in homing_axes:
+            if self.dc_module and axis == self.dc_module.axis:
+                rail = self.dc_module.get_primary_rail().get_rail()
+            else:
+                rail = self.rails[axis]
+            self.limits[axis] = rail.get_range()
 
     def note_z_not_homed(self):
         # Helper for Safe Z Home

--- a/klippy/kinematics/hybrid_corexy.py
+++ b/klippy/kinematics/hybrid_corexy.py
@@ -72,7 +72,7 @@ class HybridCoreXYKinematics:
             self.dc_module is not None
             and "PRIMARY" == self.dc_module.get_status()["carriage_1"]
         ):
-            return [pos[0] - pos[1], pos[1], pos[2]]
+            return [pos[3] - pos[1], pos[1], pos[2]]
         else:
             return [pos[0] + pos[1], pos[1], pos[2]]
 
@@ -83,14 +83,15 @@ class HybridCoreXYKinematics:
         if l <= h:
             self.limits[i] = range
 
-    def override_rail(self, i, rail):
-        self.rails[i] = rail
-
     def set_position(self, newpos, homing_axes):
         for i, rail in enumerate(self.rails):
             rail.set_position(newpos)
-            if i in homing_axes:
-                self.limits[i] = rail.get_range()
+        for axis in homing_axes:
+            if self.dc_module and axis == self.dc_module.axis:
+                rail = self.dc_module.get_primary_rail().get_rail()
+            else:
+                rail = self.rails[axis]
+            self.limits[axis] = rail.get_range()
 
     def note_z_not_homed(self):
         # Helper for Safe Z Home

--- a/klippy/kinematics/hybrid_corexz.py
+++ b/klippy/kinematics/hybrid_corexz.py
@@ -72,7 +72,7 @@ class HybridCoreXZKinematics:
             self.dc_module is not None
             and "PRIMARY" == self.dc_module.get_status()["carriage_1"]
         ):
-            return [pos[0] - pos[2], pos[1], pos[2]]
+            return [pos[3] - pos[2], pos[1], pos[2]]
         else:
             return [pos[0] + pos[2], pos[1], pos[2]]
 
@@ -83,14 +83,15 @@ class HybridCoreXZKinematics:
         if l <= h:
             self.limits[i] = range
 
-    def override_rail(self, i, rail):
-        self.rails[i] = rail
-
     def set_position(self, newpos, homing_axes):
         for i, rail in enumerate(self.rails):
             rail.set_position(newpos)
-            if i in homing_axes:
-                self.limits[i] = rail.get_range()
+        for axis in homing_axes:
+            if self.dc_module and axis == self.dc_module.axis:
+                rail = self.dc_module.get_primary_rail().get_rail()
+            else:
+                rail = self.rails[axis]
+            self.limits[axis] = rail.get_range()
 
     def note_z_not_homed(self):
         # Helper for Safe Z Home

--- a/klippy/kinematics/idex_modes.py
+++ b/klippy/kinematics/idex_modes.py
@@ -51,7 +51,13 @@ class DualCarriages:
     def get_rails(self):
         return self.dc
 
-    def toggle_active_dc_rail(self, index, override_rail=False):
+    def get_primary_rail(self):
+        for rail in self.dc:
+            if rail.mode == PRIMARY:
+                return rail
+        return None
+
+    def toggle_active_dc_rail(self, index):
         toolhead = self.printer.lookup_object("toolhead")
         toolhead.flush_step_generation()
         pos = toolhead.get_position()
@@ -61,8 +67,6 @@ class DualCarriages:
             if i != index:
                 if dc.is_active():
                     dc.inactivate(pos)
-                if override_rail:
-                    kin.override_rail(3, dc_rail)
         target_dc = self.dc[index]
         if target_dc.mode != PRIMARY:
             newpos = (
@@ -71,8 +75,6 @@ class DualCarriages:
                 + pos[self.axis + 1 :]
             )
             target_dc.activate(PRIMARY, newpos, old_position=pos)
-            if override_rail:
-                kin.override_rail(self.axis, target_dc.get_rail())
             toolhead.set_position(newpos)
         kin.update_limits(self.axis, target_dc.get_rail().get_range())
 
@@ -86,10 +88,10 @@ class DualCarriages:
             # the same direction and the first carriage homes on the second one
             enumerated_dcs.reverse()
         for i, dc_rail in enumerated_dcs:
-            self.toggle_active_dc_rail(i, override_rail=True)
+            self.toggle_active_dc_rail(i)
             kin.home_axis(homing_state, self.axis, dc_rail.get_rail())
         # Restore the original rails ordering
-        self.toggle_active_dc_rail(0, override_rail=True)
+        self.toggle_active_dc_rail(0)
 
     def get_status(self, eventtime=None):
         return {


### PR DESCRIPTION
idex_mode would swap the X and dual-carriage rail in some cases (homing), but not in others. As such, the position calculation was correct while homing, but incorrect for the second carriage during normal moves. This commit fixes homing to work without swapped rails, removes the swapping of rails while homing, and removes the ability to swap rails (as it is now no longer used). Fix has been tested in a Hybrid_CoreXY IDEX printer (Voron Double Dragon). Hybrid_CoreXZ has identical changes and is similar enough that I am confident it will work as intended. Changes to cartesion seem simple enough, but would benefit from someone running a couple of tests.

Klipper PR: https://github.com/Klipper3d/klipper/pull/6486