### PR TITLE
Per Sensor temp_ignore_limits

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,9 @@ All dates in this document are approximate.
 
 ## Changes
 
+20240519: `temp_ignore_limits` is now a list where you enter all the sensors
+that should be ignored.
+
 20240430: The `adc_ignore_limits` parameter in the `[danger_options]`
 config section has been renamed to `temp_ignore_limits` and it now
 covers all possible temperature sensors.

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -94,11 +94,11 @@ A collection of DangerKlipper-specific system options
 #   Tolerance (in mm) for distance moved in the second homing. Ensures the
 #   second homing distance closely matches the `min_home_dist` when using
 #   sensorless homing. The default is 0.5mm.
-#temp_ignore_limits: False
-#   When set to true, this parameter ignores the min_value and max_value
-#   limits for temperature sensors. It prevents shutdowns due to
+#temp_ignore_limits:
+#   A list of temperature sensors which should ignore their min and max 
+#   temperatures. It prevents shutdowns due to
 #   'ADC out of range' and similar errors by allowing readings outside the
-#   specified range without triggering a shutdown. The default is False.
+#   specified range without triggering a shutdown. The default are None.
 #autosave_includes: False
 #   When set to true, SAVE_CONFIG will recursively read [include ...] blocks
 #   for conflicts to autosave data. Any configurations updated will be backed

--- a/klippy/extras/adc_temperature.py
+++ b/klippy/extras/adc_temperature.py
@@ -21,6 +21,7 @@ RANGE_CHECK_COUNT = 4
 class PrinterADCtoTemperature:
     def __init__(self, config, adc_convert):
         self.adc_convert = adc_convert
+        self.name = config.get_name().split()[-1]
         ppins = config.get_printer().lookup_object("pins")
         self.mcu_adc = ppins.setup_pin("adc", config.get("sensor_pin"))
         self.mcu_adc.setup_adc_callback(REPORT_TIME, self.adc_callback)
@@ -38,7 +39,7 @@ class PrinterADCtoTemperature:
         self.temperature_callback(read_time + SAMPLE_COUNT * SAMPLE_TIME, temp)
 
     def setup_minmax(self, min_temp, max_temp):
-        if get_danger_options().temp_ignore_limits:
+        if self.name in get_danger_options().temp_ignore_limits:
             danger_check_count = 0
         else:
             danger_check_count = RANGE_CHECK_COUNT

--- a/klippy/extras/aht10.py
+++ b/klippy/extras/aht10.py
@@ -37,6 +37,9 @@ class AHT10:
         self.report_time = config.getint("aht10_report_time", 30, minval=5)
         self.temp = self.min_temp = self.max_temp = self.humidity = 0.0
         self.sample_timer = self.reactor.register_timer(self._sample_aht10)
+        self.ignore_limits = (
+            self.name in get_danger_options().temp_ignore_limits
+        )
         self.printer.add_object("aht10 " + self.name, self)
         self.printer.register_event_handler(
             "klippy:connect", self.handle_connect
@@ -153,10 +156,8 @@ class AHT10:
             return self.reactor.NEVER
 
         if (
-            self.temp < self.min_temp
-            or self.temp > self.max_temp
-            and not get_danger_options().temp_ignore_limits
-        ):
+            self.temp < self.min_temp or self.temp > self.max_temp
+        ) and not self.ignore_limits:
             self.printer.invoke_shutdown(
                 "AHT10 temperature %0.1f outside range of %0.1f:%.01f"
                 % (self.temp, self.min_temp, self.max_temp)

--- a/klippy/extras/bme280.py
+++ b/klippy/extras/bme280.py
@@ -186,6 +186,9 @@ class BME280:
 
         self.temp = self.pressure = self.humidity = self.gas = self.t_fine = 0.0
         self.min_temp = self.max_temp = self.range_switching_error = 0.0
+        self.ignore_limits = (
+            self.name in get_danger_options().temp_ignore_limits
+        )
         self.max_sample_time = None
         self.dig = self.sample_timer = None
         self.chip_type = "BMP280"
@@ -435,7 +438,7 @@ class BME280:
             self.humidity = self._compensate_humidity_bme280(humid_raw)
         if (
             self.temp < self.min_temp or self.temp > self.max_temp
-        ) and not get_danger_options().temp_ignore_limits:
+        ) and not self.ignore_limits:
             self.printer.invoke_shutdown(
                 "BME280 temperature %0.1f outside range of %0.1f:%.01f"
                 % (self.temp, self.min_temp, self.max_temp)

--- a/klippy/extras/danger_options.py
+++ b/klippy/extras/danger_options.py
@@ -29,16 +29,7 @@ class DangerOptions:
             "homing_elapsed_distance_tolerance", 0.5, minval=0.0
         )
 
-        temp_ignore_limits = False
-        if config.getboolean("temp_ignore_limits", None) is None:
-            adc_ignore_limits = config.getboolean("adc_ignore_limits", None)
-            if adc_ignore_limits is not None:
-                config.deprecate("adc_ignore_limits")
-                temp_ignore_limits = adc_ignore_limits
-
-        self.temp_ignore_limits = config.getboolean(
-            "temp_ignore_limits", temp_ignore_limits
-        )
+        self.temp_ignore_limits = config.getlist("temp_ignore_limits", [])
 
         self.autosave_includes = config.getboolean("autosave_includes", False)
         self.bgflush_extra_time = config.getfloat(

--- a/klippy/extras/ds18b20.py
+++ b/klippy/extras/ds18b20.py
@@ -39,7 +39,7 @@ class DS18B20:
                 self.oid,
                 sid,
                 DS18_MAX_CONSECUTIVE_ERRORS,
-                int(get_danger_options().temp_ignore_limits),
+                int(self.name in get_danger_options().temp_ignore_limits),
             )
         )
 

--- a/klippy/extras/htu21d.py
+++ b/klippy/extras/htu21d.py
@@ -109,6 +109,9 @@ class HTU21D:
         self.deviceId = config.get("sensor_type")
         self.temp = self.min_temp = self.max_temp = self.humidity = 0.0
         self.sample_timer = self.reactor.register_timer(self._sample_htu21d)
+        self.ignore_limits = (
+            self.name in get_danger_options().temp_ignore_limits
+        )
         self.printer.add_object("htu21d " + self.name, self)
         self.printer.register_event_handler(
             "klippy:connect", self.handle_connect
@@ -246,7 +249,7 @@ class HTU21D:
 
         if (
             self.temp < self.min_temp or self.temp > self.max_temp
-        ) and not get_danger_options().temp_ignore_limits:
+        ) and not self.ignore_limits:
             self.printer.invoke_shutdown(
                 "HTU21D temperature %0.1f outside range of %0.1f:%.01f"
                 % (self.temp, self.min_temp, self.max_temp)

--- a/klippy/extras/lm75.py
+++ b/klippy/extras/lm75.py
@@ -38,6 +38,9 @@ class LM75:
         )
         self.temp = self.min_temp = self.max_temp = 0.0
         self.sample_timer = self.reactor.register_timer(self._sample_lm75)
+        self.ignore_limits = (
+            self.name in get_danger_options().temp_ignore_limits
+        )
         self.printer.add_object("lm75 " + self.name, self)
         self.printer.register_event_handler(
             "klippy:connect", self.handle_connect
@@ -82,7 +85,7 @@ class LM75:
 
         if (
             self.temp < self.min_temp or self.temp > self.max_temp
-        ) and not get_danger_options().temp_ignore_limits:
+        ) and not self.ignore_limits:
             self.printer.invoke_shutdown(
                 "LM75 temperature %0.1f outside range of %0.1f:%.01f"
                 % (self.temp, self.min_temp, self.max_temp)

--- a/klippy/extras/sht3x.py
+++ b/klippy/extras/sht3x.py
@@ -57,6 +57,9 @@ class SHT3X:
         self.deviceId = config.get("sensor_type")
         self.temp = self.min_temp = self.max_temp = self.humidity = 0.0
         self.sample_timer = self.reactor.register_timer(self._sample_sht3x)
+        self.ignore_limits = (
+            self.name in get_danger_options().temp_ignore_limits
+        )
         self.printer.add_object("sht3x " + self.name, self)
         self.printer.register_event_handler(
             "klippy:connect", self.handle_connect
@@ -127,7 +130,7 @@ class SHT3X:
 
         if (
             self.temp < self.min_temp or self.temp > self.max_temp
-        ) and not get_danger_options().temp_ignore_limits:
+        ) and not self.ignore_limits:
             self.printer.invoke_shutdown(
                 "sht3x: temperature %0.1f outside range of %0.1f:%.01f"
                 % (self.temp, self.min_temp, self.max_temp)

--- a/klippy/extras/spi_temperature.py
+++ b/klippy/extras/spi_temperature.py
@@ -20,6 +20,7 @@ MAX_INVALID_COUNT = 3
 class SensorBase:
     def __init__(self, config, chip_type, config_cmd=None, spi_mode=1):
         self.printer = config.get_printer()
+        self.name = config.get_name().split()[-1]
         self.chip_type = chip_type
         self._callback = None
         self.min_sample_value = self.max_sample_value = 0
@@ -49,17 +50,17 @@ class SensorBase:
         return REPORT_TIME
 
     def _build_config(self):
+        if self.name in get_danger_options().temp_ignore_limits:
+            danger_check_count = 0
+        else:
+            danger_check_count = MAX_INVALID_COUNT
+
         self.mcu.add_config_cmd(
             "config_thermocouple oid=%u spi_oid=%u thermocouple_type=%s"
             % (self.oid, self.spi.get_oid(), self.chip_type)
         )
         clock = self.mcu.get_query_slot(self.oid)
         self._report_clock = self.mcu.seconds_to_clock(REPORT_TIME)
-
-        if get_danger_options().temp_ignore_limits:
-            danger_check_count = 0
-        else:
-            danger_check_count = MAX_INVALID_COUNT
 
         self.mcu.add_config_cmd(
             "query_thermocouple oid=%u clock=%u rest_ticks=%u"

--- a/klippy/extras/temperature_mcu.py
+++ b/klippy/extras/temperature_mcu.py
@@ -16,6 +16,7 @@ RANGE_CHECK_COUNT = 4
 class PrinterTemperatureMCU:
     def __init__(self, config):
         self.printer = config.get_printer()
+        self.name = config.get_name().split()[-1]
         self.base_temperature = self.slope = None
         self.temp1 = self.adc1 = self.temp2 = self.adc2 = None
         self.min_temp = self.max_temp = 0.0
@@ -42,7 +43,7 @@ class PrinterTemperatureMCU:
         query_adc = config.get_printer().load_object(config, "query_adc")
         query_adc.register_adc(config.get_name(), self.mcu_adc)
 
-        if get_danger_options().temp_ignore_limits:
+        if self.name in get_danger_options().temp_ignore_limits:
             self._danger_check_count = 0
         else:
             self._danger_check_count = RANGE_CHECK_COUNT

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -840,10 +840,9 @@ class MCU:
             prefix = "Previous MCU '%s' shutdown: " % (self._name,)
 
         append_msgs = []
-        if (
-            msg.startswith("ADC out of range")
-            or msg.startswith("Thermocouple reader fault")
-        ) and not get_danger_options().temp_ignore_limits:
+        if msg.startswith("ADC out of range") or msg.startswith(
+            "Thermocouple reader fault"
+        ):
             pheaters = self._printer.lookup_object("heaters")
             heaters = [
                 pheaters.lookup_heater(n) for n in pheaters.available_heaters

--- a/test/klippy/danger_options.cfg
+++ b/test/klippy/danger_options.cfg
@@ -8,7 +8,7 @@ log_bed_mesh_at_startup: False
 log_shutdown_info: False
 allow_plugin_override: True
 multi_mcu_trsync_timeout: 0.05
-temp_ignore_limits: True
+temp_ignore_limits: extruder
 autosave_includes: True
 bgflush_extra_time: 0.250
 


### PR DESCRIPTION
modifies temp_ignore_limits to take a list of sensors that should be ignored instead of ignoreing all

- [x] pr title makes sense
- [x] squashed to 1 commit
- [x] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
