### PR TITLE
Per Sensor ignore limits V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ If I want my printer to light itself on fire, I should be able to make my printe
 
 - [temperature_fan: curve control algorithm](https://github.com/DangerKlippers/danger-klipper/pull/193)
 
+- [per sensor temp_ignore_limits](https://github.com/DangerKlippers/danger-klipper/pull/276)
+
 If you're feeling adventurous, take a peek at the extra features in the bleeding-edge branch [feature documentation](docs/Bleeding_Edge.md)
 and [feature configuration reference](docs/Config_Reference_Bleeding_Edge.md):
 

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1018,6 +1018,9 @@ per_move_pressure_advance: False
 #   If true, uses pressure advance constant from trapq when processing moves
 #   This causes changes to pressure advance be taken into account immediately,
 #   for all moves in the current queue, rather than ~250ms later once the queue gets flushed
+is_non_critical: False
+#   If true, klipper will not go into a shutdown state when the sensor exceeds
+#   the defined temperature limits.
 
 ```
 
@@ -1488,6 +1491,9 @@ See also: [extended g-code commands](G-Codes.md#z_thermal_adjust).
 #gcode_id:
 #   See the "heater_generic" section for the definition of this
 #   parameter.
+is_non_critical: False
+#   If true, klipper will not go into a shutdown state when the sensor exceeds
+#   the defined temperature limits.
 ```
 
 ## Customized homing
@@ -2809,6 +2815,9 @@ target temperature.
 #max_temp:
 #   See the "extruder" section for the definition of the above
 #   parameters.
+is_non_critical: False
+#   If true, klipper will not go into a shutdown state when the sensor exceeds
+#   the defined temperature limits.
 ```
 
 ### [temperature_sensor]
@@ -2827,6 +2836,9 @@ temperature sensors that are reported via the M105 command.
 #gcode_id:
 #   See the "heater_generic" section for the definition of this
 #   parameter.
+is_non_critical: False
+#   If true, klipper will not go into a shutdown state when the sensor exceeds
+#   the defined temperature limits.
 ```
 
 ## Temperature sensors

--- a/klippy/extras/adc_temperature.py
+++ b/klippy/extras/adc_temperature.py
@@ -21,6 +21,10 @@ RANGE_CHECK_COUNT = 4
 class PrinterADCtoTemperature:
     def __init__(self, config, adc_convert):
         self.adc_convert = adc_convert
+        self.is_non_critical = (
+            get_danger_options().temp_ignore_limits
+            or config.getboolean("is_non_critical", False)
+        )
         ppins = config.get_printer().lookup_object("pins")
         self.mcu_adc = ppins.setup_pin("adc", config.get("sensor_pin"))
         self.mcu_adc.setup_adc_callback(REPORT_TIME, self.adc_callback)
@@ -38,7 +42,7 @@ class PrinterADCtoTemperature:
         self.temperature_callback(read_time + SAMPLE_COUNT * SAMPLE_TIME, temp)
 
     def setup_minmax(self, min_temp, max_temp):
-        if get_danger_options().temp_ignore_limits:
+        if self.is_non_critical:
             danger_check_count = 0
         else:
             danger_check_count = RANGE_CHECK_COUNT

--- a/klippy/extras/aht10.py
+++ b/klippy/extras/aht10.py
@@ -35,6 +35,10 @@ class AHT10:
             config, default_addr=AHT10_I2C_ADDR, default_speed=100000
         )
         self.report_time = config.getint("aht10_report_time", 30, minval=5)
+        self.is_non_critical = (
+            get_danger_options().temp_ignore_limits
+            or config.getboolean("is_non_critical", False)
+        )
         self.temp = self.min_temp = self.max_temp = self.humidity = 0.0
         self.sample_timer = self.reactor.register_timer(self._sample_aht10)
         self.printer.add_object("aht10 " + self.name, self)
@@ -155,7 +159,7 @@ class AHT10:
         if (
             self.temp < self.min_temp
             or self.temp > self.max_temp
-            and not get_danger_options().temp_ignore_limits
+            and not self.is_non_critical
         ):
             self.printer.invoke_shutdown(
                 "AHT10 temperature %0.1f outside range of %0.1f:%.01f"

--- a/klippy/extras/bme280.py
+++ b/klippy/extras/bme280.py
@@ -174,6 +174,10 @@ class BME280:
         self.os_pres = config.getint("bme280_oversample_pressure", 2)
         self.gas_heat_temp = config.getint("bme280_gas_target_temp", 320)
         self.gas_heat_duration = config.getint("bme280_gas_heat_duration", 150)
+        self.is_non_critical = (
+            get_danger_options().temp_ignore_limits
+            or config.getboolean("is_non_critical", False)
+        )
         logging.info(
             "BMxx80: Oversampling: Temp %dx Humid %dx Pressure %dx"
             % (
@@ -435,7 +439,7 @@ class BME280:
             self.humidity = self._compensate_humidity_bme280(humid_raw)
         if (
             self.temp < self.min_temp or self.temp > self.max_temp
-        ) and not get_danger_options().temp_ignore_limits:
+        ) and not self.is_non_critical:
             self.printer.invoke_shutdown(
                 "BME280 temperature %0.1f outside range of %0.1f:%.01f"
                 % (self.temp, self.min_temp, self.max_temp)

--- a/klippy/extras/ds18b20.py
+++ b/klippy/extras/ds18b20.py
@@ -24,6 +24,10 @@ class DS18B20:
         self.report_time = config.getfloat(
             "ds18_report_time", DS18_REPORT_TIME, minval=DS18_MIN_REPORT_TIME
         )
+        self.is_non_critical = (
+            get_danger_options().temp_ignore_limits
+            or config.getboolean("is_non_critical", False)
+        )
         self._mcu = mcu.get_printer_mcu(self.printer, config.get("sensor_mcu"))
         self.oid = self._mcu.create_oid()
         self._mcu.register_response(
@@ -39,7 +43,7 @@ class DS18B20:
                 self.oid,
                 sid,
                 DS18_MAX_CONSECUTIVE_ERRORS,
-                int(get_danger_options().temp_ignore_limits),
+                int(self.is_non_critical),
             )
         )
 

--- a/klippy/extras/htu21d.py
+++ b/klippy/extras/htu21d.py
@@ -101,6 +101,10 @@ class HTU21D:
         self.hold_master_mode = config.getboolean("htu21d_hold_master", False)
         self.resolution = config.get("htu21d_resolution", "TEMP12_HUM08")
         self.report_time = config.getint("htu21d_report_time", 30, minval=5)
+        self.is_non_critical = (
+            get_danger_options().temp_ignore_limits
+            or config.getboolean("is_non_critical", False)
+        )
         if self.resolution not in HTU21D_RESOLUTIONS:
             raise config.error(
                 "Invalid HTU21D Resolution. Valid are %s"
@@ -246,7 +250,7 @@ class HTU21D:
 
         if (
             self.temp < self.min_temp or self.temp > self.max_temp
-        ) and not get_danger_options().temp_ignore_limits:
+        ) and not self.is_non_critical:
             self.printer.invoke_shutdown(
                 "HTU21D temperature %0.1f outside range of %0.1f:%.01f"
                 % (self.temp, self.min_temp, self.max_temp)

--- a/klippy/extras/lm75.py
+++ b/klippy/extras/lm75.py
@@ -36,6 +36,10 @@ class LM75:
         self.report_time = config.getfloat(
             "lm75_report_time", LM75_REPORT_TIME, minval=LM75_MIN_REPORT_TIME
         )
+        self.is_non_critical = (
+            get_danger_options().temp_ignore_limits
+            or config.getboolean("is_non_critical", False)
+        )
         self.temp = self.min_temp = self.max_temp = 0.0
         self.sample_timer = self.reactor.register_timer(self._sample_lm75)
         self.printer.add_object("lm75 " + self.name, self)
@@ -82,7 +86,7 @@ class LM75:
 
         if (
             self.temp < self.min_temp or self.temp > self.max_temp
-        ) and not get_danger_options().temp_ignore_limits:
+        ) and not self.is_non_critical:
             self.printer.invoke_shutdown(
                 "LM75 temperature %0.1f outside range of %0.1f:%.01f"
                 % (self.temp, self.min_temp, self.max_temp)

--- a/klippy/extras/sht3x.py
+++ b/klippy/extras/sht3x.py
@@ -55,6 +55,10 @@ class SHT3X:
         )
         self.report_time = config.getint("sht3x_report_time", 1, minval=1)
         self.deviceId = config.get("sensor_type")
+        self.is_non_critical = (
+            get_danger_options().temp_ignore_limits
+            or config.getboolean("is_non_critical", False)
+        )
         self.temp = self.min_temp = self.max_temp = self.humidity = 0.0
         self.sample_timer = self.reactor.register_timer(self._sample_sht3x)
         self.printer.add_object("sht3x " + self.name, self)
@@ -127,7 +131,7 @@ class SHT3X:
 
         if (
             self.temp < self.min_temp or self.temp > self.max_temp
-        ) and not get_danger_options().temp_ignore_limits:
+        ) and not self.is_non_critical:
             self.printer.invoke_shutdown(
                 "sht3x: temperature %0.1f outside range of %0.1f:%.01f"
                 % (self.temp, self.min_temp, self.max_temp)

--- a/klippy/extras/spi_temperature.py
+++ b/klippy/extras/spi_temperature.py
@@ -35,6 +35,10 @@ class SensorBase:
         mcu.register_response(
             self._handle_spi_response, "thermocouple_result", oid
         )
+        self.is_non_critical = (
+            get_danger_options().temp_ignore_limits
+            or config.getboolean("is_non_critical", False)
+        )
         mcu.register_config_callback(self._build_config)
 
     def setup_minmax(self, min_temp, max_temp):
@@ -56,7 +60,7 @@ class SensorBase:
         clock = self.mcu.get_query_slot(self.oid)
         self._report_clock = self.mcu.seconds_to_clock(REPORT_TIME)
 
-        if get_danger_options().temp_ignore_limits:
+        if self.is_non_critical:
             danger_check_count = 0
         else:
             danger_check_count = MAX_INVALID_COUNT

--- a/klippy/extras/temperature_combined.py
+++ b/klippy/extras/temperature_combined.py
@@ -19,6 +19,10 @@ class PrinterSensorCombined:
         self.sensor_names = config.getlist("sensor_list")
         # get maximum_deviation parameter from config
         self.max_deviation = config.getfloat("maximum_deviation", above=0.0)
+        self.is_non_critical = (
+            get_danger_options().temp_ignore_limits
+            or config.getboolean("is_non_critical", False)
+        )
         # ensure compatibility with itself
         self.sensor = self
         # get empty list for sensors, could be any sensor class or a heater
@@ -79,7 +83,7 @@ class PrinterSensorCombined:
         # check if values are out of max_deviation range
         if (
             max(values) - min(values)
-        ) > self.max_deviation and not get_danger_options().temp_ignore_limits:
+        ) > self.max_deviation and not self.is_non_critical:
             self.printer.invoke_shutdown(
                 "COMBINED SENSOR maximum deviation exceeded limit of %0.1f, "
                 "max sensor value %0.1f, min sensor value %0.1f."

--- a/klippy/extras/temperature_host.py
+++ b/klippy/extras/temperature_host.py
@@ -18,6 +18,10 @@ class Temperature_HOST:
         self.reactor = self.printer.get_reactor()
         self.name = config.get_name().split()[-1]
         self.path = config.get("sensor_path", RPI_PROC_TEMP_FILE)
+        self.is_non_critical = (
+            get_danger_options().temp_ignore_limits
+            or config.getboolean("is_non_critical", False)
+        )
 
         self.temp = self.min_temp = self.max_temp = 0.0
 
@@ -62,7 +66,7 @@ class Temperature_HOST:
 
         if (
             self.temp < self.min_temp or self.temp > self.max_temp
-        ) and not get_danger_options().temp_ignore_limits:
+        ) and not self.is_non_critical:
             self.printer.invoke_shutdown(
                 "HOST temperature %0.1f outside range of %0.1f:%.01f"
                 % (self.temp, self.min_temp, self.max_temp)

--- a/klippy/extras/temperature_mcu.py
+++ b/klippy/extras/temperature_mcu.py
@@ -22,6 +22,10 @@ class PrinterTemperatureMCU:
         self.debug_read_cmd = None
         # Read config
         mcu_name = config.get("sensor_mcu", "mcu")
+        self.is_non_critical = (
+            get_danger_options().temp_ignore_limits
+            or config.getboolean("is_non_critical", False)
+        )
         self.reference_voltage = config.getfloat(
             "reference_voltage", default=3.3
         )
@@ -42,7 +46,7 @@ class PrinterTemperatureMCU:
         query_adc = config.get_printer().load_object(config, "query_adc")
         query_adc.register_adc(config.get_name(), self.mcu_adc)
 
-        if get_danger_options().temp_ignore_limits:
+        if self.is_non_critical:
             self._danger_check_count = 0
         else:
             self._danger_check_count = RANGE_CHECK_COUNT

--- a/test/klippy/temp_ignore_limits.cfg
+++ b/test/klippy/temp_ignore_limits.cfg
@@ -1,0 +1,166 @@
+# Test config with many different types of temperature sensors
+[stepper_x]
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PE5
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_y]
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PJ1
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_z]
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PD3
+position_endstop: 0.5
+position_max: 200
+
+[extruder]
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 33.5
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PB4
+sensor_type: AD595
+sensor_pin: PK5
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 250
+is_non_critical: True
+
+[heater_bed]
+heater_pin: PH5
+sensor_type: PT100 INA826
+sensor_pin: PK6
+control: watermark
+min_temp: 0
+max_temp: 130
+is_non_critical: True
+
+[temperature_fan test_max6675]
+pin: PH6
+min_temp: 0
+max_temp: 100
+control: watermark
+sensor_type: MAX6675
+sensor_pin: PE4
+is_non_critical: True
+
+[temperature_fan test_max31855]
+pin: PG5
+min_temp: 0
+max_temp: 100
+control: watermark
+sensor_type: MAX31855
+sensor_pin: PE3
+is_non_critical: True
+
+[temperature_fan test_max31856]
+pin: PH3
+min_temp: 0
+max_temp: 100
+control: watermark
+sensor_type: MAX31856
+sensor_pin: PH4
+is_non_critical: True
+
+[temperature_fan test_max31865]
+pin: PB6
+min_temp: 0
+max_temp: 100
+control: watermark
+sensor_type: MAX31865
+sensor_pin: PB7
+is_non_critical: True
+
+[thermistor my_custom_thermistor]
+temperature1: 25
+resistance1: 100000
+temperature2: 100
+resistance2: 1500
+temperature3: 250
+resistance3: 100
+
+[temperature_fan test_custom_thermistor]
+pin: PJ0
+min_temp: 0
+max_temp: 100
+control: watermark
+sensor_type: my_custom_thermistor
+sensor_pin: PF3
+is_non_critical: True
+
+[adc_temperature my_custom_adc]
+temperature1: 25
+voltage1: 1
+temperature2: 100
+voltage2: 2
+temperature3: 250
+voltage3: 3
+
+[temperature_fan test_custom_adc]
+pin: PH1
+min_temp: 0
+max_temp: 100
+control: watermark
+sensor_type: my_custom_adc
+sensor_pin: PF4
+is_non_critical: True
+
+[adc_temperature my_custom_resistance_adc]
+temperature1: 25
+resistance1: 1000
+temperature2: 100
+resistance2: 2000
+temperature3: 250
+resistance3: 3000
+
+[temperature_sensor test_custom_resistance_adc]
+sensor_type: my_custom_resistance_adc
+sensor_pin: PF5
+
+[temperature_sensor test_PT1000]
+sensor_type: PT1000
+sensor_pin: PK1
+
+[temperature_sensor test_combined]
+sensor_type: temperature_combined
+sensor_list: temperature_sensor test_PT1000,extruder,heater_bed
+combination_method: mean
+maximum_deviation: 20.0
+is_non_critical: True
+
+[controller_fan test_controller_fan]
+pin: PH0
+
+[mcu]
+serial: /dev/ttyACM0
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100

--- a/test/klippy/temp_ignore_limits.test
+++ b/test/klippy/temp_ignore_limits.test
@@ -1,0 +1,17 @@
+# Tests for various temperature sensors
+DICTIONARY atmega2560.dict
+CONFIG temp_ignore_limits.cfg
+
+# Set various temperatures
+M104 S100
+M105
+
+M140 S60
+M105
+
+M140 S0
+
+# Test "wait for temp" g-code
+M109 S100
+M109 S60
+M105


### PR DESCRIPTION
Lets you define temperature sensors as "non_critical" which makes them ignore their temperature limits

_Enter a good description of whats being changed and WHY

## Checklist

- [ ] pr title makes sense
- [ ] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
