### PR TITLE
Update heaters.py, on mpc_experimental, to include reasonable default filament values

### DIFF
--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -356,12 +356,12 @@ class Heater:
                     "filament_diameter", above=0.0, default=1.75
                 )
                 temp_profile["filament_density"] = config_section.getfloat(
-                    "filament_density", above=0.0, default=0.0
+                    "filament_density", above=0.0, default=1.2
                 )
                 temp_profile[
                     "filament_heat_capacity"
                 ] = config_section.getfloat(
-                    "filament_heat_capacity", above=0.0, default=0.0
+                    "filament_heat_capacity", above=0.0, default=1.8
                 )
 
                 ambient_sensor_name = config_section.get(


### PR DESCRIPTION
Change filament defaults to density=1.2 and specific heat=1.8. Based on a review of filament properties this should be good defaults to allow filament feed forward to work well for most users out of the box.

MPC doc, currently in PR, will be updated to reflect these default values (https://github.com/DangerKlippers/danger-klipper/pull/275)_

## Checklist

- [X ] pr title makes sense
- [ X] squashed to 1 commit
- [ N/A] added a test case if possible
- [ X] if new feature, added to the readme
- [ N/A] ci is happy and green
