### PR TITLE
bump jinja2 and markupsafe versions

### DIFF
--- a/scripts/klippy-requirements.txt
+++ b/scripts/klippy-requirements.txt
@@ -6,7 +6,7 @@ cffi==1.15.1
 pyserial==3.4
 greenlet==2.0.2 ; python_version < '3.12'
 greenlet==3.0.3 ; python_version >= '3.12'
-Jinja2==2.11.3
+Jinja2==3.1.4
 python-can==3.3.4
-markupsafe==1.1.1 # https://github.com/Klipper3d/klipper/pull/5286
+markupsafe==2.1.5
 numpy==1.25.2


### PR DESCRIPTION
we don't support python2, and thats the reason those are pinned to old versions

python-can/pyserial you are the next 💯 

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [x] ci is happy and green
