### PR TITLE
core: expose danger-klipper to moonraker

### DIFF
--- a/klippy/webhooks.py
+++ b/klippy/webhooks.py
@@ -386,6 +386,7 @@ class WebHooks:
         src_path = os.path.dirname(__file__)
         klipper_path = os.path.normpath(os.path.join(src_path, ".."))
         response = {
+            "app": "Danger-Klipper",
             "state": state,
             "state_message": state_message,
             "hostname": socket.gethostname(),

--- a/scripts/buildcommands.py
+++ b/scripts/buildcommands.py
@@ -621,7 +621,7 @@ class HandleVersions:
     def update_data_dictionary(self, data):
         data["version"] = self.version
         data["build_versions"] = self.toolstr
-        data["app"] = "Klipper"
+        data["app"] = "Danger-Klipper"
         data["license"] = "GNU GPLv3"
 
     def generate_code(self, options):


### PR DESCRIPTION
This will help frontends (Fluidd/Mainsail) validate whether the user is running Danger-Klipper or native Klipper.

`_handle_info_request()` response is rendered raw to Moonraker's `/printer/info`, so no changes to Moonraker are needed.

I also took the opportunity to rename the MCU data dict for firmware builds.

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [x] ci is happy and green
