### PR TITLE
MPC: Increase accuracy

### DIFF
--- a/klippy/extras/control_mpc.py
+++ b/klippy/extras/control_mpc.py
@@ -456,19 +456,22 @@ class MpcCalibrate:
             self.heater.set_control(old_control)
             self.heater.alter_target(0.0)
 
-    def wait_settle(self, max_rate):
+    def wait_settle(self, max_rate, min_time=8.0):
         last_temp = None
         next_check = None
         samples = []
 
         def process(eventtime):
-            temp, _ = self.heater.get_temp(eventtime)
+            temp, target = self.heater.get_temp(eventtime)
+            if target > 1 and abs(target - temp) > 0.1:
+                samples.clear() # reset
+                return True
             samples.append((eventtime, temp))
-            while samples[0][0] < eventtime - 10.0:
+            while samples[0][0] < eventtime - (min_time + 2.0):
                 samples.pop(0)
             dT = samples[-1][1] - samples[0][1]
             dt = samples[-1][0] - samples[0][0]
-            if dt < 8.0:
+            if dt < min_time:
                 return True
             rate = abs(dT / dt)
             return not rate < max_rate
@@ -541,8 +544,8 @@ class MpcCalibrate:
             % (target_temp,)
         )
 
-        self.wait_settle(0.2)
-        gcmd.respond_info("Temperature stable, performing power tests")
+        gcmd.respond_info("Waiting for heat soak")
+        self.wait_settle(0.05)
 
         fan = self.orig_control.cooling_fan
 
@@ -559,6 +562,9 @@ class MpcCalibrate:
                     curtime = self.heater.reactor.monotonic()
                     print_time = fan.get_mcu().estimated_print_time(curtime)
                     fan.set_speed(print_time + PIN_MIN_TIME, speed)
+                    gcmd.respond_info("Waiting for temperature to stabilize")
+                    self.wait_settle(0.01, 20.0)
+                    gcmd.respond_info(f"Temperature stable, measuring power usage with {speed*100.:.0f}% fan speed")
                     power = self.measure_power(
                         ambient_max_measure_time, ambient_measure_sample_time
                     )

--- a/klippy/extras/control_mpc.py
+++ b/klippy/extras/control_mpc.py
@@ -494,11 +494,11 @@ class MpcCalibrate:
         def process(eventtime):
             temp, _ = self.heater.get_temp(eventtime)
             samples.append((eventtime, temp))
-            while samples[0][0] < eventtime - 10:
+            while samples[0][0] < eventtime - 10.0:
                 samples.pop(0)
             dT = samples[-1][1] - samples[0][1]
             dt = samples[-1][0] - samples[0][0]
-            if dt < 8:
+            if dt < 8.0:
                 return True
             rate = abs(dT / dt)
             return not rate < max_rate

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -382,7 +382,7 @@ class Printer:
 
     wait_interrupted = WaitInterruption
 
-    def wait_while(self, condition_cb, error_on_cancel=True):
+    def wait_while(self, condition_cb, error_on_cancel=True, interval=1.0):
         """
         receives a callback
         waits until callback returns False
@@ -397,7 +397,7 @@ class Printer:
                     raise WaitInterruption("Command interrupted")
                 else:
                     return
-            eventtime = self.reactor.pause(eventtime + 1.0)
+            eventtime = self.reactor.pause(eventtime + interval)
 
 
 ######################################################################


### PR DESCRIPTION
This is a change to MPC to make the ambient heat loss actually make sense. See examples.

Command: MPC_CALIBRATE HEATER=extruder TARGET=230
Done on an Ender 3 V2 Neo with 40 Watt heating element, copper heat block.

Original:
0% fan average power: 21.81 W
50% fan average power: 20.74 W
100% fan average power: 21.01 W

0.1 temperature target:
0% fan average power: 20.86 W
50% fan average power: 20.68 W
100% fan average power: 20.50 W

heat soak and stabilization:
0% fan average power: 20.65 W
50% fan average power: 20.61 W
100% fan average power: 21.53 W

0.1 target, heat soak and stabilization:
0% fan average power: 20.23 W
50% fan average power: 21.01 W
100% fan average power: 21.97 W

The 0.1 degree target method was better in some ways but it did not have the desired effect. That is because the extruder isn't getting heat soaked.
Heat soaking and stabilization is way better, though it still is not perfect. (Perhaps it is not heat soaked enough? We might need to play around with the 0.05.)
Both methods seem to work best but it comes at a significant time cost. Given that you should basically run it and forget it I would say that is worth it.

This change has flaws. Certain hardware might not be able to stabilize properly and that will cause swings too high for the 0.1 degree target. Therefore the 0.1 degree should probably be configurable and maybe not the default.

An alternative would be to build another function to keep track of the PWM of the heater and wait for that to stabilize. It probably wouldn't matter much in terms of time though.