### PR TITLE
mcu: expose the mcu app name to mcu.get_status and logs

### DIFF
--- a/klippy/console.py
+++ b/klippy/console.py
@@ -73,11 +73,9 @@ class KeyboardReader:
             self.ser.connect_pipe(self.serialport)
         msgparser = self.ser.get_msgparser()
         message_count = len(msgparser.get_messages())
+        app = msgparser.get_app_info()
         version, build_versions = msgparser.get_version_info()
-        self.output(
-            "Loaded %d commands (%s / %s)"
-            % (message_count, version, build_versions)
-        )
+        self.output(f"Loaded {message_count} commands ({app} {version} / {build_versions})")
         self.output(
             "MCU config: %s"
             % (

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -992,11 +992,11 @@ class MCU:
 
     def _log_info(self):
         msgparser = self._serial.get_msgparser()
+        app = msgparser.get_app_info()
         message_count = len(msgparser.get_messages())
         version, build_versions = msgparser.get_version_info()
         log_info = [
-            "Loaded MCU '%s' %d commands (%s / %s)"
-            % (self._name, message_count, version, build_versions),
+            f"Loaded MCU '{self._name}' {message_count} commands ({app} {version} / {build_versions})",
             "MCU '%s' config: %s"
             % (
                 self._name,
@@ -1095,7 +1095,9 @@ class MCU:
             self._printer.register_event_handler(
                 "klippy:firmware_restart", self._firmware_restart_bridge
             )
+        app = msgparser.get_app_info()
         version, build_versions = msgparser.get_version_info()
+        self._get_status_info["app"] = app
         self._get_status_info["mcu_version"] = version
         self._get_status_info["mcu_build_versions"] = build_versions
         self._get_status_info["mcu_constants"] = msgparser.get_constants()

--- a/klippy/msgproto.py
+++ b/klippy/msgproto.py
@@ -475,6 +475,7 @@ class MessageParser:
                 all_messages, commands.values(), output.values()
             )
             self.config.update(data.get("config", {}))
+            self.app = data.get("app", "")
             self.version = data.get("version", "")
             self.build_versions = data.get("build_versions", "")
         except error as e:
@@ -485,6 +486,9 @@ class MessageParser:
 
     def get_raw_data_dictionary(self):
         return self.raw_identify_data
+
+    def get_app_info(self):
+        return self.app
 
     def get_version_info(self):
         return self.version, self.build_versions


### PR DESCRIPTION
That's a continuation of https://github.com/DangerKlippers/danger-klipper/pull/285, but now for mcus
UIs now can show if MCUs are running Danger-Klipper or Klipper with no modifications required to Moonraker

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [x] ci is happy and green
