### PR TITLE
Don't use incomplete clock sync for SPI temperature; always warn

### DIFF
--- a/klippy/clocksync.py
+++ b/klippy/clocksync.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2016-2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import logging, math
+import logging, math, traceback
 
 RTT_AGE = 0.000010 / (60.0 * 60.0)
 DECAY = 1.0 / 30.0
@@ -237,10 +237,18 @@ class SecondarySync(ClockSync):
 
     # clock frequency conversions
     def print_time_to_clock(self, print_time):
+        if self.clock_adj[1] == 1.0:
+            logging.warning("Clock not yet synchronized, clock is untrustworthy")
+            for line in traceback.format_stack():
+                logging.warning(line.strip())
         adjusted_offset, adjusted_freq = self.clock_adj
         return int((print_time - adjusted_offset) * adjusted_freq)
 
     def clock_to_print_time(self, clock):
+        if self.clock_adj[1] == 1.0:
+            logging.warning("Clock not yet synchronized, print time is untrustworthy")
+            for line in traceback.format_stack():
+                logging.warning(line.strip())
         adjusted_offset, adjusted_freq = self.clock_adj
         return clock / adjusted_freq + adjusted_offset
 


### PR DESCRIPTION
The problem is outlined in https://github.com/Klipper3d/klipper/issues/6619

In this PR, I have done two things:
- Add a simple check to avoid reporting the wrong temperature
- Add some warnings for when an uncompleted clock sync is used in `clock_to_print_time()` and `print_time_to_clock()`

There may be a better solution to this; I'm not sure. I headed down the path of making `clock_to_print_time()` and `print_time_to_clock()` raise an exception, but there's just too much stuff that happily accepts the wrong value for my little non-python-fluent brain to handle it all.