### PR TITLE
bugfix: sensorless return to run current

### DIFF
--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -265,12 +265,12 @@ class Homing:
         for rail in affected_rails:
             chs = rail.get_tmc_current_helpers()
             for ch in chs:
-                if ch is not None and ch.needs_home_current_change():
-                    dwell_time = max(dwell_time, ch.current_change_dwell_time)
+                if ch is not None:
                     if pre_homing:
-                        ch.set_current_for_homing(print_time)
+                        dwell_time = ch.set_current_for_homing(print_time)
                     else:
-                        ch.set_current_for_normal(print_time)
+                        dwell_time = ch.set_current_for_normal(print_time)
+
         if dwell_time:
             self.toolhead.dwell(dwell_time)
 

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -833,16 +833,13 @@ class BaseTMCCurrentHelper:
             f"tmc {self.name}: set_actual_current() new actual_current: {self.actual_current}"
         )
 
-    def set_current_for_homing(self, print_time) -> float:
-        if self.needs_home_current_change:
+    def set_current_for_homing(self, print_time, pre_homing) -> float:
+        if pre_homing and self.needs_home_current_change:
             self.set_current(
                 self.req_home_current, self.req_hold_current, print_time
             )
             return self.current_change_dwell_time
-        return 0.0
-
-    def set_current_for_normal(self, print_time) -> float:
-        if self.needs_run_current_change:
+        elif not pre_homing and self.needs_run_current_change:
             self.set_current(
                 self.req_run_current, self.req_hold_current, print_time
             )

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -833,15 +833,21 @@ class BaseTMCCurrentHelper:
             f"tmc {self.name}: set_actual_current() new actual_current: {self.actual_current}"
         )
 
-    def set_current_for_homing(self, print_time):
-        self.set_current(
-            self.req_home_current, self.req_hold_current, print_time
-        )
+    def set_current_for_homing(self, print_time) -> float:
+        if self.needs_home_current_change:
+            self.set_current(
+                self.req_home_current, self.req_hold_current, print_time
+            )
+            return self.current_change_dwell_time
+        return 0.0
 
-    def set_current_for_normal(self, print_time):
-        self.set_current(
-            self.req_run_current, self.req_hold_current, print_time
-        )
+    def set_current_for_normal(self, print_time) -> float:
+        if self.needs_run_current_change:
+            self.set_current(
+                self.req_run_current, self.req_hold_current, print_time
+            )
+            return self.current_change_dwell_time
+        return 0.0
 
     def needs_current_changes(self, run_current, hold_current, force=False):
         if (


### PR DESCRIPTION
I introduced a bug in https://github.com/DangerKlippers/danger-klipper/pull/298. 
`_set_current_homing` and `_set_current_post_homing` were consolidated into a single method, and I missed the difference between `ch.needs_home_current_change` and `ch.needs_run_current_change`.

A new method, `ch.needs_running_current_change`, now validates if any running current needs changing.  


## Checklist

- [x] pr title makes sense
- [ ] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [x] ci is happy and green
