### PR TITLE
gcode_macro: adds RELOAD_GCODE_MACROS

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ See the [Danger Features document](https://dangerklipper.io/Danger_Features.html
 
 - [gcode: HEATER_INTERRUPT gcode command](https://github.com/DangerKlippers/danger-klipper/pull/94)
 
+- [gcode: RELOAD_GCODE_MACROS command](https://github.com/DangerKlippers/danger-klipper/pull/305)
+
 - [probe: dockable Probe](https://github.com/DangerKlippers/danger-klipper/pull/43) ([klipper#4328](https://github.com/Klipper3d/klipper/pull/4328))
 
 - [probe: drop the first result](https://github.com/DangerKlippers/danger-klipper/pull/2) ([klipper#3397](https://github.com/Klipper3d/klipper/issues/3397))

--- a/docs/Danger_Features.md
+++ b/docs/Danger_Features.md
@@ -49,6 +49,7 @@
 
 - The jinja `do` extension has been enabled. You can now call functions in your macros without resorting to dirty hacks: `{% do array.append(5) %}`
 - The python [`math`](https://docs.python.org/3/library/math.html) library is available to macros. `{math.sin(math.pi * variable)}` and more!
+- New [`RELOAD_GCODE_MACROS`](./G-Codes.md#reload_gcode_macros) G-Code command to reload `[gcode_macro]` templates without requiring a restart.
 
 ## [Plugins](./Plugins.md)
 Extend your Danger Klipper installation with custom plugins.

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -380,7 +380,7 @@ commands are available when a
 - `MOVE_TO_DETACH_PROBE`: Move away from the dock to disconnect the probe
   from the toolhead.
 - `MOVE_AVOIDING_DOCK [X=<value>] [Y=<value>] [SPEED=<value>]`: Move to the
-  defined point (absolute coordinates) avoiding the safe dock area 
+  defined point (absolute coordinates) avoiding the safe dock area
 
 ### [dual_carriage]
 
@@ -741,6 +741,12 @@ enabled (also see the
 `SET_GCODE_VARIABLE MACRO=<macro_name> VARIABLE=<name> VALUE=<value>`:
 This command allows one to change the value of a gcode_macro variable
 at run-time. The provided VALUE is parsed as a Python literal.
+
+#### RELOAD_GCODE_MACROS
+`RELOAD_GCODE_MACROS`: This command reads the config files and reloads
+all previously loaded gcode templates. It does not load new `[gcode_macro]`
+objects or unload deleted ones. Variables modified with SET_GCODE_VARIABLE
+remain unaffected.
 
 ### [gcode_move]
 

--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -273,9 +273,12 @@ class PrinterConfig:
         self.unused_options = []
         self.save_config_pending = False
         gcode = self.printer.lookup_object("gcode")
-        gcode.register_command(
-            "SAVE_CONFIG", self.cmd_SAVE_CONFIG, desc=self.cmd_SAVE_CONFIG_help
-        )
+        if "SAVE_CONFIG" not in gcode.ready_gcode_handlers:
+            gcode.register_command(
+                "SAVE_CONFIG",
+                self.cmd_SAVE_CONFIG,
+                desc=self.cmd_SAVE_CONFIG_help,
+            )
 
     def get_printer(self):
         return self.printer

--- a/klippy/console.py
+++ b/klippy/console.py
@@ -75,7 +75,9 @@ class KeyboardReader:
         message_count = len(msgparser.get_messages())
         app = msgparser.get_app_info()
         version, build_versions = msgparser.get_version_info()
-        self.output(f"Loaded {message_count} commands ({app} {version} / {build_versions})")
+        self.output(
+            f"Loaded {message_count} commands ({app} {version} / {build_versions})"
+        )
         self.output(
             "MCU config: %s"
             % (

--- a/test/klippy/gcode_jinja2_ext_do.test
+++ b/test/klippy/gcode_jinja2_ext_do.test
@@ -22,3 +22,9 @@ NONE_TEST
 
 # Move again
 G1 Z9
+
+# Reload macros command
+RELOAD_GCODE_MACROS
+
+# test again
+NONE_TEST


### PR DESCRIPTION
new RELOAD_GCODE_MACROS g-code command to reload gcode_macro templates without a firmware restart

## Checklist

- [x] pr title makes sense
- [ ] squashed to 1 commit
- [x] added a test case if possible
- [x] if new feature, added to the readme
- [ ] ci is happy and green
