### PR TITLE
bugfix/fan: shutdown shouldnt use max_power when hardware pwm is not set

### DIFF
--- a/klippy/extras/fan.py
+++ b/klippy/extras/fan.py
@@ -58,9 +58,15 @@ class Fan:
         self.mcu_fan = ppins.setup_pin("pwm", config.get("pin"))
         self.mcu_fan.setup_max_duration(0.0)
         self.mcu_fan.setup_cycle_time(cycle_time, hardware_pwm)
-        shutdown_power = max(0.0, min(self.max_power, shutdown_speed))
-        self.mcu_fan.setup_start_value(0.0, shutdown_power)
 
+        if hardware_pwm:
+            shutdown_power = max(0.0, min(self.max_power, shutdown_speed))
+        else:
+            # the config allows shutdown_power to be > 0 and < 1, but it is validated
+            # in MCU_pwm._build_config().
+            shutdown_power = max(0.0, shutdown_speed)
+
+        self.mcu_fan.setup_start_value(0.0, shutdown_power)
         self.enable_pin = None
         enable_pin = config.get("enable_pin", None)
         if enable_pin is not None:

--- a/test/klippy/fan_pwm_scaling.cfg
+++ b/test/klippy/fan_pwm_scaling.cfg
@@ -54,6 +54,12 @@ pin: PB5
 min_power: 0.1
 max_power: 1
 
+[fan_generic xxx]
+pin: PB6
+min_power: 0.1
+shutdown_speed: 1
+max_power: 0.95
+
 [mcu]
 serial: /dev/ttyACM0
 


### PR DESCRIPTION
As reported in https://github.com/DangerKlippers/danger-klipper/issues/290, the config below throws an error because we are trying to min() between `max_power` and `shutdown_speed`.

```
[fan]
max_power: 0.95
shutdown_speed: 1
hardware_pwm: False (default)
```

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
