### PR TITLE
bugfix/heaters: auto detect generic heaters when looking up heater objects

### DIFF
--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -889,6 +889,8 @@ class PrinterHeaters:
         return self.available_heaters
 
     def lookup_heater(self, heater_name):
+        if " " in heater_name:
+            heater_name = heater_name.split(" ", 1)[1]
         if heater_name not in self.heaters:
             raise self.printer.config_error(
                 "Unknown heater '%s'" % (heater_name,)


### PR DESCRIPTION
As reported in a Discord help thread, the feature that reports faulty heaters is throwing an error if the heater was a prefixed one (e.g., generic_heater). The reason is that `pheaters.available_heaters` returns the full object name, including the prefix, but `pheaters.lookup_heater` doesn't accept that. 

instead of splitting the name there, I preferred to modify `lookup_heater` to improve future uses of it. 

_Enter a good description of whats being changed and WHY

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
