### PR TITLE
feat/resonance_tester: accepts ACCEL_PER_HZ in TEST_RESONANCES

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ See the [Danger Features document](https://dangerklipper.io/Danger_Features.html
 
 - [shaper_calibrate: store and expose accel_per_hz](https://github.com/DangerKlippers/danger-klipper/pull/224)
 
+- [resonance_tester: accepts ACCEL_PER_HZ in TEST_RESONANCES](https://github.com/DangerKlippers/danger-klipper/pull/312)
+
 - [mcu: support for AT32F403](https://github.com/DangerKlippers/danger-klipper/pull/284)
 
 If you're feeling adventurous, take a peek at the extra features in the bleeding-edge-v2 branch [feature documentation](docs/Bleeding_Edge.md)

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -380,7 +380,7 @@ commands are available when a
 - `MOVE_TO_DETACH_PROBE`: Move away from the dock to disconnect the probe
   from the toolhead.
 - `MOVE_AVOIDING_DOCK [X=<value>] [Y=<value>] [SPEED=<value>]`: Move to the
-  defined point (absolute coordinates) avoiding the safe dock area 
+  defined point (absolute coordinates) avoiding the safe dock area
 
 ### [dual_carriage]
 
@@ -1264,8 +1264,8 @@ all enabled accelerometer chips.
 `TEST_RESONANCES AXIS=<axis> OUTPUT=<resonances,raw_data>
 [NAME=<name>] [FREQ_START=<min_freq>] [FREQ_END=<max_freq>]
 [HZ_PER_SEC=<hz_per_sec>] [CHIPS=<adxl345_chip_name>]
-[POINT=x,y,z] [INPUT_SHAPING=[<0:1>]]`: Runs the resonance
-test in all configured probe points for the requested "axis" and
+[POINT=x,y,z] [ACCEL_PER_HZ=<accel_per_hz>] [INPUT_SHAPING=[<0:1>]]`: Runs
+the resonance test in all configured probe points for the requested "axis" and
 measures the acceleration using the accelerometer chips configured for
 the respective axis. "axis" can either be X or Y, or specify an
 arbitrary direction as `AXIS=dx,dy`, where dx and dy are floating
@@ -1274,10 +1274,10 @@ point numbers defining a direction vector (e.g. `AXIS=X`, `AXIS=Y`, or
 and `AXIS=-dx,-dy` is equivalent. `adxl345_chip_name` can be one or
 more configured adxl345 chip,delimited with comma, for example
 `CHIPS="adxl345, adxl345 rpi"`. Note that `adxl345` can be omitted from
-named adxl345 chips. If POINT is specified it will override the point(s)
-configured in `[resonance_tester]`. If `INPUT_SHAPING=0` or not set(default),
-disables input shaping for the resonance testing, because
-it is not valid to run the resonance testing with the input shaper
+named adxl345 chips. If POINT or ACCEL_PER_HZ are specified,
+they will override the corresponding fields configured in `[resonance_tester]`.
+If `INPUT_SHAPING=0` or not set(default), disables input shaping for the resonance
+testing, because it is not valid to run the resonance testing with the input shaper
 enabled. `OUTPUT` parameter is a comma-separated list of which outputs
 will be written. If `raw_data` is requested, then the raw
 accelerometer data is written into a file or a series of files


### PR DESCRIPTION
as suggested by @lhndo in https://github.com/DangerKlippers/danger-klipper/issues/295, it complements https://github.com/DangerKlippers/danger-klipper/pull/224 and allows the user to try different accel_per_hz without having to edit the config and restart the firmware.

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [x] if new feature, added to the readme
- [x] ci is happy and green
