### PR TITLE
trad_rack: make compatible with change to PrinterExtruder.last_positi…

### DIFF
--- a/klippy/extras/trad_rack.py
+++ b/klippy/extras/trad_rack.py
@@ -2653,7 +2653,7 @@ class TradRackExtruderSyncManager:
             prev_toolhead = self.toolhead
             external_toolhead = self.tr_toolhead
             self.reset_fil_driver()
-            new_pos = 0.0
+            new_pos = [0.0, 0.0, 0.0]
         elif sync_type == FIL_DRIVER_TO_EXTRUDER:
             steppers = self.fil_driver_rail.get_steppers()
             self._prev_trapq = self.tr_toolhead.get_trapq()
@@ -2663,6 +2663,8 @@ class TradRackExtruderSyncManager:
             prev_toolhead = self.tr_toolhead
             external_toolhead = self.toolhead
             new_pos = extruder.last_position
+            if not isinstance(new_pos, list):
+                new_pos = [new_pos, 0.0, 0.0]
         else:
             raise Exception("Invalid sync_type: %d" % sync_type)
 
@@ -2675,7 +2677,7 @@ class TradRackExtruderSyncManager:
                 stepper.set_stepper_kinematics(stepper_kinematics)
             )
             stepper.set_trapq(external_trapq)
-            stepper.set_position((new_pos, 0.0, 0.0))
+            stepper.set_position(new_pos)
             prev_toolhead.step_generators.remove(stepper.generate_steps)
             external_toolhead.register_step_generator(stepper.generate_steps)
         self.sync_state = sync_type


### PR DESCRIPTION
…on from DangerKlippers/danger-klipper@a5b1714

This change makes the trad_rack module compatible with DangerKlippers/danger-klipper@a5b1714 (which changed `PrinterExtruder.last_position` from a single float to a list). When the trad_rack module accesses `last_position`, it now checks whether the variable is a list or not and compensates before passing the position into `MCU_stepper.set_position()`.

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [x] ci is happy and green
