### PR TITLE
Dockable_probe : Fix _move_avoiding_dock if no safe_area

### DIFF
--- a/klippy/extras/dockable_probe.py
+++ b/klippy/extras/dockable_probe.py
@@ -669,7 +669,7 @@ class DockableProbe:
         dx, dy = x1 - cx, y1 - cy
         d = hypot(dx, dy)
         if d == 0:
-            return self.detach_position
+            return point1[:2] # Unable to determine exit point 
         # Ensure exit point is outside dock area.
         magnitude = self.safe_dock_distance + 10e-8
         x1 = cx + magnitude * dx / d

--- a/klippy/extras/dockable_probe.py
+++ b/klippy/extras/dockable_probe.py
@@ -589,8 +589,11 @@ class DockableProbe:
         end_point = end_point[:2]
         dock = self.dock_position[:2]
         radius = self.safe_dock_distance
+        if radius == 0:
+            self.toolhead.manual_move([end_point[0], end_point[1], None], speed)
+            return
 
-        # redefine star_point outside safe dock area
+        # redefine start_point outside safe dock area
         coords = []
         if radius > self._get_distance(dock, start_point):
             start_point = self._get_closest_exitpoint(start_point)
@@ -667,7 +670,8 @@ class DockableProbe:
         d = hypot(dx, dy)
         if d == 0:
             return self.detach_position
-        magnitude = self.safe_dock_distance
+        # Ensure exit point is outside dock area.
+        magnitude = self.safe_dock_distance + 10e-8
         x1 = cx + magnitude * dx / d
         y1 = cy + magnitude * dy / d
         x2 = cx - magnitude * dx / d


### PR DESCRIPTION
According to this issue https://github.com/DangerKlippers/danger-klipper/issues/322,  when the `safe_dock_distance` is zero _move_avoiding_dock may not correctly calculate an exit point. This PR disables the avoidance function in this situation. 

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [x] ci is happy and green
