### PR TITLE
motan: Fix logic error resulting in incorrect stepper phase graphing (#6612)

### DIFF
--- a/scripts/motan/readlog.py
+++ b/scripts/motan/readlog.py
@@ -338,7 +338,7 @@ class HandleStepPhase:
                 self._pull_block(req_time)
                 continue
             step_pos = step_data[data_pos][1]
-            return (step_pos - self.mcu_phase_offset) % self.phases
+            return (step_pos + self.mcu_phase_offset) % self.phases
 
     def _pull_block(self, req_time):
         step_data = self.step_data


### PR DESCRIPTION
The mcu_phase_offset should be added not subtracted.

Klipper PR: https://github.com/Klipper3d/klipper/pull/6612

and ruff fixes