### PR TITLE
MPC doc update to support PR#333

### DIFF
--- a/docs/MPC.md
+++ b/docs/MPC.md
@@ -75,7 +75,7 @@ These can be specified in the config but should not need to be changed from the 
   This parameter affects how quickly the model learns and it represents the ratio of temperature difference applied per second. A value of 1.0 represents no smoothing used in the model.  
   
 - `min_ambient_change:`  
-  _Default Value: 1.0 (deg C)_  
+  _Default Value: 1.0 (deg C/s)_  
   Larger values of MIN_AMBIENT_CHANGE will result in faster convergence but will also cause the simulated ambient temperature to flutter somewhat chaotically around the ideal value.  
   
 - `steady_state_rate:`  

--- a/docs/MPC.md
+++ b/docs/MPC.md
@@ -2,82 +2,88 @@
 
 Model Predictive Control (MPC) is an advanced temperature control method that offers an alternative to traditional PID control. MPC leverages a system model to simulate the temperature of the hotend and adjusts the heater power to align with the target temperature.  
 
-Unlike reactive methods, MPC operates proactively, making adjustments in anticipation of temperature fluctuations. It utilizes a model of the hotend, taking into account factors such as the thermal masses of the system, heater power, heat loss to ambient air, and fans, and heat transfer into the filament. This model allows MPC to predict the amount of heat energy that will be dissipated from the hotend over a given duration, and it compensates for this by adjusting the heater power accordingly. As a result, MPC can accurately calculate the necessary heat energy input to maintain a steady temperature or to transition to a new temperature.
+Unlike reactive methods, MPC operates proactively, adjusting in anticipation of temperature fluctuations. It utilizes a model of the hotend, considering factors such as the thermal masses of the system, heater power, heat loss to ambient air, and fans, and heat transfer into the filament. This model allows MPC to predict the amount of heat energy that will be dissipated from the hotend over a given duration, and it compensates for this by adjusting the heater power accordingly. As a result, MPC can accurately calculate the necessary heat energy input to maintain a steady temperature or to transition to a new temperature.
 
 MPC offers several advantages over PID control:
 
-- **Faster and more responsive temperature control:** MPC’s proactive approach allows it to respond more quickly and accurately to changes in temperature. 
+- **Faster and more responsive temperature control:** MPC’s proactive approach allows it to respond more quickly and accurately to changes in temperature from fans or flow rate changes. 
 - **Broad functionality with single calibration:** Once calibrated, MPC functions effectively across a wide range of printing temperatures.  
 - **Simplified calibration process:** MPC is easier to calibrate compared to traditional PID control. 
 - **Compatibility with all hotend sensor types:** MPC works with all types of hotend sensors, including those that produce noisy temperature readings.
-- **Versatility with heater types:** MPC performs equally well with standard cartridge heaters and PTC heaters.
-- **Applicable to both hotends and beds:** MPC can be used to control the temperature of both hotends and beds.
+- **Versatility with heater types:** MPC performs well with standard cartridge heaters and PTC heaters.
 - **Effective for high and low flow hotends:** Regardless of the flow rate of the hotend, MPC maintains effective temperature control.     
 
 > [!CAUTION]
 > This feature controls the portions of the 3D printer that can get very hot. All standard Danger Klipper warnings apply. Please report all issues and bugs to github or discord.
 
-# Configuration
+# Basic Configuration
 
-To use MPC as the temperature controller set the following configuration parameters in the appropriate heater section of the config.   
-Currently only [extruder] and [heater_bed] heater types are supported.  
+To use MPC as the temperature controller for the extruder use the following basic configuration block.
 
 ```
-[extruder] OR [heater_bed]
+[extruder]
 control: mpc
-heater_power:
-#   Nameplate heater power in watts. 
-
-#   Note that for a PTC, a non-linear heater, MPC may not work optimally due
-#   to the change in power output relative to temperature for this style of
-#   heater. Setting heater_power to the power output at the expected printing
-#   temperature is recommended.
-cooling_fan: fan 
-#   This is the fan that is cooling extruded filament and the hotend.
-#   cooling_fan is supported for [heater_bed] but accurate performance has
-#   not been verified.
-#   Specifying "fan" will automatically use the part cooling fan.
-#   Bed fans could be used for the [heater_bed] by specifying
-#   <fan_generic BedFans> for example.
-#ambient_temp_sensor: <temperature_sensor sensor_name>
-#   Optional. If this is not given MPC will estimate this parameter
-#   (recommended).
-#   It can use any sensor, but it should be a temperature sensor in proximity
-#   to the hotend or measuring the ambient air surrounding the hotend such as
-#   a chamber sensor. 
-#   This is used for initial state temperature and calibration but not for
-#   actual control.
-#   Example sensor: temperature_sensor beacon_coil
+heater_power: 50  
+cooling_fan: fan
+filament_diameter: 1.75
+filament_density: 1.20
+filament_heat_capacity: 1.8 
 ```
+
+- `control: mpc`  
+  *Required*  
+  The temperature control method.
+  
+- `heater_power: 50`  
+  *Required*   
+  The nameplate heater power in watts.  
+  For a PTC, a non-linear heater, MPC may not work optimally due
+  to the change in power output relative to heater temperature for this style of
+  heater. Setting heater_power to the power output at the expected printing
+  temperature is recommended.
+  
+- `cooling_fan: fan`  
+  _Default Value: fan_  
+  This is the fan that is cooling extruded filament and the hotend. 
+  Specifying "fan" will automatically use the part cooling fan.
+  
+- `filament_diameter: fan`  
+  _Default Value: 1.75 (mm)_  
+  This is the filament diameter.  
+  
+- `filament_density: 1.20`   
+  _Default Value: 1.20 (g/mm^3)_  
+  This is the material density of the filament being printed.
+  
+- `filament_heat_capacity: 1.80`  
+  _Default Value: 1.80 (J/g/K)_  
+  This is the material specific heat capacity of the filament being printed.
+  
+## PTC Heater Power
+
+The `heater power:` for PTC style heaters is recommended to be set at the normal print temperature for the printer. Some common PTC heaters are given below for reference. If your heater is not listed the manufacturer should be able to provide a temperature and power curve.
+
+| Heater Temp (C) | Rapido 2 (W) | Rapido 1 (W) | Dragon Ace (W) | Revo 40 (W) |Revo 60 (W) |
+|:---------------:|:------------:|:------------:|:--------------:|:-----------:|:----------:|
+| 180             | 72           | 52           | 51             | 30          |45          |
+| 200             | 70           | 51           | 48             | 29          |44          |
+| 220             | 67           | 50           | 46             | 28          |43          |
+| 240             | 65           | 49           | 44             | 28          |42          |
+| 260             | 64           | 48           | 43             | 27          |40          |
+| 280             | 62           | 47           | 41             | 27          |39          |
+| 300             | 60           | 46           | 39             | 26          |38          |
 
 ## Filament Feed Forward Configuration
 
+The Filament feed forward (FFF) feature allows MPC to look forward and see changes in extrusion rates which could require more or less heat input to maintain target temperature. This feature substantially improves the accuracy and responsiveness of the model during printing. It is enabled by default and can be defined is more detail with `filament_density` and `filament_heat_capacity` config parameters. The default values are set to cover a wide range of standard materials including ABS, ASA, PLA, PETG. 
 
-MPC can look forward to changes in extrusion rates which could require more or less heat input to maintain target temperatures. This substantially improves the accuracy and responsiveness of the model during printing. 
-
-
-These should only be set under [extruder] and are not valid for [heater_bed]. 
-
-```
-#filament_diameter: 1.75
-#   (mm)
-#filament_density: 1.2
-#   1.2 (g/mm^3) is the default to cover a wide range of standard
-#   materials including ABS, ASA, PLA, PETG.
-#filament_heat_capacity: 1.8
-#   1.8 (J/g/K) is the default to cover a wide range of standard
-#   materials including ABS, ASA, PLA, PETG.
-```
-
-Filament feed forward parameters can be set, for the printer session, via the command line or custom G-Code with the following command.
+ FFF parameters can be set, for the printer session, via the `MPC_SET` G-Code command:  
 
 `MPC_SET HEATER=<heater> FILAMENT_DENSITY=<value> FILAMENT_HEAT_CAPACITY=<value>`
 
-`HEATER=<heater>`: Only [extruder] is supported.
-
-`FILAMENT_DENSITY=<value> `:  Filament density in g/mm^3
-
-`FILAMENT_HEAT_CAPACITY=<value>`: Filament heat capacity in J/g/K
+- `HEATER`: Only extruder is supported
+- `FILAMENT_DENSITY`:  Filament density in g/mm^3
+- `FILAMENT_HEAT_CAPACITY`: Filament heat capacity in J/g/K
 
 For example, updating the filament material properties for ASA would be:   
 
@@ -85,86 +91,67 @@ For example, updating the filament material properties for ASA would be:
 MPC_SET HEATER=extruder FILAMENT_DENSITY=1.07 FILAMENT_HEAT_CAPACITY=1.7  
 ```
 
-## Optional model parameters
+## Optional Config Parameters
 
-These can be tuned but should not need changing from the default values. 
+These can be specified in the config but should not need to be changed from the default values for most users.
 
-```
-#target_reach_time: 2.0
-#   (sec) 
-#smoothing: 0.83
-#   (sec)
-#   This parameter affects how quickly the model learns and it represents
-#   the ratio of temperature difference applied per second.
-#   A value of 1.0 represents no smoothing used in the model.
-#min_ambient_change: 1.0
-#   (deg C)
-#   Larger values of MIN_AMBIENT_CHANGE will result in faster convergence
-#   but will also cause the simulated ambient temperature to flutter
-#   somewhat chaotically around the ideal value.  
-#steady_state_rate: 0.5
-#   (deg C/s)
-```
-
-## Example configuration block
-
-```
-[extruder]
-control: mpc
-heater_power: 50  
-cooling_fan: fan
-filament_density: 1.20
-filament_heat_capacity: 1.8
-
-[heater_bed]
-control: mpc
-heater_power: 400  
-```
-
-> [!IMPORTANT]
-> Restart the firmware to enable MPC and proceed to calibration.
-
+- `target_reach_time:`  
+  _Default Value: 2.0 (sec)_  
+ 
+- `smoothing:`  
+  _Default Value: 0.83 (sec)_  
+  This parameter affects how quickly the model learns and it represents the ratio of temperature difference applied per second. A value of 1.0 represents no smoothing used in the model.  
+  
+- `min_ambient_change:`  
+  _Default Value: 1.0 (deg C)_  
+  Larger values of MIN_AMBIENT_CHANGE will result in faster convergence but will also cause the simulated ambient temperature to flutter somewhat chaotically around the ideal value.  
+  
+- `steady_state_rate:`  
+  _Default Value: 0.5 (deg C/s)_  
+  
+- `ambient_temp_sensor: temperature_sensor <sensor_name>`  
+  _Default Value: MPC ESTIMATE_  
+  It is recommended not to specify this parameter and let MPC will estimate. This is used for initial state temperature and calibration but not for actual control.  
+  Any temperature sensor could be used, but the sensor should be in proximity to the hotend or measuring the ambient air surrounding the hotend.  
+  
 # Calibration
 
 The MPC default calibration routine takes the following steps:
 
-- Cool to ambient: The calibration routine needs to know the approximate ambient temperature. It switches the part cooling fan on and waits until the hotend temperature stops decreasing relative to ambient.
-- Heat past 200°C: Measure the point where the temperature is increasing most rapidly, and the time and temperature at that point. Also, three temperature measurements are needed at some point after the initial latency has taken effect. The tuning algorithm heats the hotend to over 200°C.
-- Hold temperature while measuring ambient heat-loss: At this point enough is known for the MPC algorithm to engage. The calibration routine makes a best guess at the overshoot past 200°C which will occur and targets this temperature for about a minute while ambient heat-loss is measured without (and optionally with) the fan.
-- MPC calibration routine creates the appropriate model constants and saves them for use. At this time the model parameters are temporary and not yet saved to the printer configuration via SAVE_CONFIG.  
+> 1. Cool to ambient: The calibration routine needs to know the approximate ambient temperature and waits until the hotend temperature stabilises and stops decreasing relative to ambient.
+> 2. Heat past 200°C: Measure the point where the temperature is increasing most rapidly, and the time and temperature at that point. Also, three temperature measurements are needed at some point after the initial latency has taken effect. 
+> 3. Hold temperature while measuring ambient heat-loss: At this point enough is known for the MPC algorithm to engage. The calibration routine makes a best guess at the overshoot past 200°C which will occur and targets this temperature for about a minute while ambient heat-loss is measured without and with the fan engaged (if a `cooling_fan` is specified)
+> 4. The MPC calibration routine creates the appropriate model constants. At this time the model parameters are temporary and not yet saved to the printer configuration.  
 
-## Hotend or Bed Calibration
+The MPC calibration routine must be run for each heater, to be controlled by MPC, in order to determine the model parameters. For an MPC calibration to be successful an extruder must be able to reach 200C. Calibration is performed with the following G-code command.
 
-The MPC calibration routine has to be run initially for each heater to be controlled using MPC. In order for MPC to be functional an extruder must be able to reach 200C and a bed to reach 90C.
+`MPC_CALIBRATE HEATER=<heater> [TARGET=<temperature>] [FAN_BREAKPOINTS=<value>]`  
 
-`MPC_CALIBRATE HEATER=<heater> [TARGET=<temperature>] [FAN_BREAKPOINTS=<value>]`
-
-`HEATER=<heater>` :The heater to be calibrated. [extruder] or [heater_bed] supported.
-
-`[TARGET=<temperature>]` : Sets the calibration temperature in degrees C. TARGET default is 200C for extruder and 90C for beds. MPC calibration is temperature independent so calibration the extruder at higher temperatures will not necessarily produce better model parameters. This is an area of exploration for advanced users
-
-`[FAN_BREAKPOINTS=<value>]` : Sets the number off fan setpoint to test during calibration. Three fan powers (0%, 50%, 100%) are tested by default. An arbitrary number breakpoints can be specified e.g. 7 breakpoints would result in (0, 16%, 33%, 50%, 66%, 83%, 100%) fan speeds. Each breakpoint adds about 20s to the calibration.
+- `HEATER=<heater>`:  
+  The extruder heater to be calibrated.  
+  
+- `TARGET=<temperature>`:  
+  _Default Value: 200 (deg C)_  
+  Sets the calibration temperature. TARGET default is 200C, which is a good target for the extruder. MPC calibration is temperature independent, so calibrating the extruder at higher temperatures will not necessarily produce better model parameters. This is an area of exploration for advanced users.  
+  
+- `FAN_BREAKPOINTS=<value>`:  
+  _Default Value: 3_  
+  Sets the number off fan setpoint to test during calibration. An arbitrary number of breakpoints can be specified e.g. 7 breakpoints would result in (0, 16%, 33%, 50%, 66%, 83%, 100%) fan speeds.
+  It is recommended to use a number that will capture one or more test points below the lowest level of fan normally used. For example, if 20% fan is the lowest commonly used speed, using 11 break points is recommended to test 10% and 20% fan at the low range.  
+  
+Default calibration of the hotend with seven fan breakpoints:  
+```
+MPC_CALIBRATE HEATER=extruder FAN_BREAKPOINTS=7
+```
 
 > [!NOTE]
-> Ensure that the part cooling fan is off before starting calibration.
+> Ensure that the part cooling fan is off before starting calibration.  
 
-Default calibration of the hotend:
-
-```
-MPC_CALIBRATE HEATER=extruder  
-```
-
-Default calibration of the bed: 
-
-```
-MPC_CALIBRATE HEATER=heater_bed TARGET=100  
-```
-
-After calibration the routine will generate the key model parameters which will be available for use in that printer session and are available in the log for future reference.  
+After successful  calibration the method will generate the key model parameters into the log for future reference.  
 
 ![Calibration Parameter Output](/docs/img/MPC_calibration_output.png)
 
-A **SAVE_CONFIG** command is then required to commit these calibrated parameters to the printer config. The save config block should then look similar to: 
+A **SAVE_CONFIG** command is then required to commit these calibrated model parameters to the printer config or the user can manually update the values. The `SAVE_CONFIG` block should then look like: 
 
 ```
 #*# [extruder]
@@ -173,39 +160,33 @@ A **SAVE_CONFIG** command is then required to commit these calibrated parameters
 #*# sensor_responsiveness = 0.0998635
 #*# ambient_transfer = 0.155082
 #*# fan_ambient_transfer=0.155082, 0.20156, 0.216441
-#*# 
-#*# [heater_bed]
-#*# control = mpc
-#*# block_heat_capacity = 2078.86
-#*# sensor_responsiveness = 0.0139945
-#*# ambient_transfer = 15.6868
 ```
 
 > [!NOTE]
-> If the [extruder] and [heater_bed] sections are located in a cfg file other than printer.cfg the SAVE_CONFIG command may not be able to write the calibration parameters and klippy will provide an error. 
+> If the [extruder] section is in a .cfg file other than printer.cfg the SAVE_CONFIG command may not be able to write the calibration parameters and klippy will provide an error. 
 
-The calibrated parameters are not suitable for pre-configuration or are not explicitly determinable. Advanced users could tweak these post calibration based on the following guidance: Slightly increasing these values will increase the temperature where MPC settles and slightly decreasing them will decrease the settling temperature.  
+These model parameters are not suitable for pre-configuration or are not explicitly determinable. Advanced users could tweak these post calibration based on the following guidance: Slightly increasing these values will increase the temperature where MPC settles and slightly decreasing them will decrease the settling temperature.  
 
-```
-#block_heat_capacity:
-#   Heat capacity of the heater block in (J/K).
-#ambient_transfer:
-#   Heat transfer from heater block to ambient in (W/K).
-#sensor_responsiveness:
-#   A single constant representing the coefficient of heat transfer from
-#   heater block to sensor and heat capacity of the sensor in (K/s/K).
-#fan_ambient_transfer:
-#   Heat transfer from heater block to ambient in with fan enabled in (W/K).
-```
+- `block_heat_capacity:`  
+  Heat capacity of the heater block in (J/K).  
+  
+- `ambient_transfer:`  
+  Heat transfer from heater block to ambient in (W/K).  
+  
+- `sensor_responsiveness:`  
+  A single constant representing the coefficient of heat transfer from heater block to sensor and heat capacity of the sensor in (K/s/K).  
+  
+- `fan_ambient_transfer:`  
+  Heat transfer from heater block to ambient in with fan enabled in (W/K).  
+  
+## Filament Physical Properties
 
-## Filament Feed Forward Physical Properties
-
-MPC works best knowing how much energy (in Joules) it takes to heat 1mm of filament by 1°C. The material values from the tables below have been curated from popular filament manufacturers and material data references. These values are sufficient for MPC to implement the filament feed forward feature.  Advanced users could tune the filament_density and filament_heat_capacity parameters based on manufacturers datasheets. 
+MPC works best knowing how much energy (in Joules) it takes to heat 1mm of filament by 1°C. The material values from the tables below have been curated from popular filament manufacturers and material data references. These values are sufficient for MPC to implement the FFF feature.  Advanced users could tune the `filament_density` and `filament_heat_capacity` parameters based on manufacturers datasheets. 
 
 ### Common Materials
 
 | Material | Density [g/cm³] | Specific heat [J/g/K] |
-| -------- | --------------- | --------------------- |
+| -------- |:---------------:|:---------------------:|
 | PLA      | 1.25            | 1.8 - 2.2             |
 | PETG     | 1.27            | 1.7 - 2.2             |
 | PC+ABS   | 1.15            | 1.5 - 2.2             |
@@ -220,28 +201,57 @@ MPC works best knowing how much energy (in Joules) it takes to heat 1mm of filam
 
 ### Common Carbon Fiber Filled Materials
 
-| Material  | Density [g/cm³] | Specific heat [J/g/K] |
-| --------- | --------------- | --------------------- |
-| ABS-CF    | 1.11            | **                    |
-| ASA-CF    | 1.11            | **                    |
-| PA6-CF    | 1.19            | **                    |
-| PC+ABS-CF | 1.22            | **                    |
-| PC+CF     | 1.36            | **                    |
-| PLA-CF    | 1.29            | **                    |
-| PETG-CF   | 1.30            | **                    |
+| Material                                     | Density [g/cm³] | Specific heat [J/g/K] |
+| -------------------------------------------- |:---------------:|:---------------------:|
+| ABS-CF                                       | 1.11            | ^                     |
+| ASA-CF                                       | 1.11            | ^                     |
+| PA6-CF                                       | 1.19            | ^                     |
+| PC+ABS-CF                                    | 1.22            | ^                     |
+| PC+CF                                        | 1.36            | ^                     |
+| PLA-CF                                       | 1.29            | ^                     |
+| PETG-CF                                      | 1.30            | ^                     |  
 
-**Use the specific heat from the base polymer
+^ Use the specific heat from the base polymer
 
-### An example macro for automatically setting these values
+# Support Macros
 
-These values are copied from the above tables, heat capacities are the middle of the range.
+## Temperature Wait
 
-Your slicer must be configured to pass the current material type to your `PRINT_START`, for PrusaSlicer and family you may use `PRINT_START MATERIAL=[filament_type[initial_extruder]] # and other values...`
+The following macro can be used to replace `M109` hotend temperature set and `M190` bed temperature set G-code commands with a macro utilizing `temperature_wait` G-codes. This can be utilized in systems where the sensor temperature takes an extended time to converge on the set temperature. 
+> [!NOTE]
+> This behaviour occurs primarily because MPC controls the modelled block temperature and not the hotend temperature sensor. For almost all cases, when temperature sensor overshoot/undershoot occurs, the block modelled temperature will be correctly at the set temperature. However, the Klipper system performs actions based on the sensor temperature only which can lead to undesirable delays in print actions with stock `M109` and `M190` commands.
 
-Then, in your `PRINT_START` macro, call `_SET_MPC_MATERIAL MATERIAL={params.MATERIAL}`
+```
+[gcode_macro M109] # Wait Hotend Temp
+rename_existing: M109.1
+gcode:
+    #Parameters
+    {% set s = params.S|float %}
+
+    M104 {% for p in params %}{'%s%s' % (p, params[p])}{% endfor %}  # Set hotend temp
+    {% if s != 0 %}
+        TEMPERATURE_WAIT SENSOR=extruder MINIMUM={s-2} MAXIMUM={s+5}   # Wait for hotend temp (within n degrees)
+    {% endif %}
+
+
+[gcode_macro M190] # Wait Bed Temp
+rename_existing: M190.1
+gcode:
+    #Parameters
+    {% set s = params.S|float %}
+
+    M140 {% for p in params %}{'%s%s' % (p, params[p])}{% endfor %}   # Set bed temp
+    {% if s != 0 %}
+        TEMPERATURE_WAIT SENSOR=heater_bed MINIMUM={s-2} MAXIMUM={s+5}  # Wait for bed temp (within n degrees)
+    {% endif %}
+```
+
+### Setting FFF Parameters From The Slicer
+
+This macro will set FFF parameters automatically when the material type is passed from the slicer. 
 
 ```ini
-[gcode_macro SET_MPC_MATERIAL]
+[gcode_macro _SET_MPC_MATERIAL]
 description: Set heater MPC parameters for a given material
 variable_filament_table:
     ## Update this table to adjust material settings
@@ -285,6 +295,24 @@ gcode:
     MPC_SET HEATER={heater} FILAMENT_DENSITY={density} FILAMENT_HEAT_CAPACITY={heat_capacity}
 ```
 
+The slicer must be configured to pass the current material type to your `PRINT_START` macro. For PrusaSlicer you should add the following parameter line to `print_start` in the Start G-Code section:
+
+```
+MATERIAL=[filament_type[initial_extruder]]
+```
+
+The print_start line, in PrusaSlicer, would look like:
+
+```
+start_print MATERIAL=[filament_type[initial_extruder]] EXTRUDER_TEMP={first_layer_temperature[initial_extruder]} BED_TEMP={first_layer_bed_temperature[initial_extruder]} CHAMBER_TEMP={chamber_temperature}
+```
+
+Then, in your `PRINT_START` macro include the following macro call:
+
+```
+_SET_MPC_MATERIAL MATERIAL={params.MATERIAL}
+```
+
 # Real-Time Model State
 
 The real-time temperatures and model states can be viewed from a browser by entering the following local address for your computer.
@@ -294,6 +322,52 @@ https://192.168.xxx.xxx:7125/printer/objects/query?extruder
 ```
 
 ![Calibration](/docs/img/MPC_realtime_output.png)
+
+# EXPERIMENTAL FEATURES
+
+## Bed Heater
+
+Using MPC for bed heater control is functional but the performance is not guaranteed or currently supported.  MPC for the bed can be configured simply.
+
+```
+[heater_bed]
+control: mpc
+heater_power: 400
+```
+
+- `control: mpc`  
+  *Required*  
+  The temperature control method.  
+  
+- `heater_power: 50`  
+  *Required*  
+  The nameplate heater power in watts.  
+  
+- `cooling_fan: fan_generic <fan_name>`  
+  _No Default Value_  
+  This is the fan cooling the bed. Optional parameter to support bed fans.  
+
+The bed should be able to reach at least 90C to perform calibration with the following G-code. 
+
+`MPC_CALIBRATE HEATER=<heater> [TARGET=<temperature>] [FAN_BREAKPOINTS=<value>]`  
+
+- `HEATER=<heater>`:  
+  The bed heater to be calibrated.  
+  
+- `TARGET=<temperature>`:  
+  _Default Value: 90 (deg C)_  
+  Sets the calibration temperature. TARGET default is 90C, which is a good target for the bed.  
+  
+- `FAN_BREAKPOINTS=<value>`:  
+  _Default Value: 3_  
+  Sets the number of fan setpoint to test during calibration.    
+
+Default calibration of the hotend with five fan breakpoints:  
+```
+MPC_CALIBRATE HEATER=heater_bed FAN_BREAKPOINTS=5
+```
+
+These calibrated model parameters need to be saved to the SAVE_CONFIG block manually or by using the `Save_Config` command.
 
 # BACKGROUND
 
@@ -316,7 +390,7 @@ No simulation is perfect and, anyway, real life ambient temperature changes. So 
 
 Steady_state_rate is used to recognize the asymptotic condition. Whenever the simulated hotend temperature changes at an absolute rate less than steady_state_rate between two successive runs of the algorithm, the steady state logic is applied. Since the algorithm runs frequently, even a small amount of noise can result in a fairly high instantaneous rate of change of hotend temperature. In practice 1°C/s seems to work well for steady_state_rate.  
 
-When in steady state, the difference between real and simulated sensor temperatures is used to drive the changes to ambient temperature. However when the temperatures are really close min_ambient_change ensures that the simulated ambient temperature converges relatively quickly. Larger values of min_ambient_change will result in faster convergence but will also cause the simulated ambient temperature to flutter somewhat chaotically around the ideal value. This is not a problem because the effect of ambient temperature is fairly small and short-term variations of even 10°C or more will not have a noticeable effect.  
+When in steady state, the difference between real and simulated sensor temperatures is used to drive the changes to ambient temperature. However, when the temperatures are really close min_ambient_change ensures that the simulated ambient temperature converges relatively quickly. Larger values of min_ambient_change will result in faster convergence but will also cause the simulated ambient temperature to flutter somewhat chaotically around the ideal value. This is not a problem because the effect of ambient temperature is fairly small and short-term variations of even 10°C or more will not have a noticeable effect.  
 
 It is important to note that the simulated ambient temperature will only converge on real world ambient temperature if the ambient heat transfer coefficients are exactly accurate. In practice this will not be the case and the simulated ambient temperature therefore also acts a correction to these inaccuracies.  
 


### PR DESCRIPTION
Big re-format and update to the MPC documentation to support MPC feature release to mainline in PR https://github.com/DangerKlippers/danger-klipper/pull/333. Primary focus was to bring the overall content format inline with other documents and make setup and configuration clear and concise. Feedback from the beta was integrated to support common issues and questions. Bed setup was moved to experimental section to help clarify that currently MPC is primary intended to be used with the extruder heater. No significant content removals IMO.

The following areas were added:

 - PTC temp-heater chart
- Note on overshoot / undershoot and how MPC controls block temp and not sensor temp.
- Temp wait macro

As with all documentation updates, I welcome review and feedback.

## Checklist

- [X ] pr title makes sense
- [ X] squashed to 1 commit
- [N/A] added a test case if possible
- [N/A] if new feature, added to the readme
- [N/A] ci is happy and green
