### PR TITLE
Reset endstop states before first home

### DIFF
--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -274,6 +274,14 @@ class Homing:
         if dwell_time:
             self.toolhead.dwell(dwell_time)
 
+    def _reset_endstop_states(self, endstops):
+        # re-querying a tmc endstop seems to reset the state
+        # otherwise it triggers almost immediately upon second home
+        # this seems to be an adequate substitute for a 2 second dwell.
+        print_time = self.toolhead.get_last_move_time()
+        for endstop in endstops:
+            endstop[0].query_endstop(print_time)
+
     def home_rails(self, rails, forcepos, movepos):
         # Notify of upcoming homing operation
         self.printer.send_event("homing:home_rails_begin", self, rails)
@@ -288,6 +296,7 @@ class Homing:
         hmove = HomingMove(self.printer, endstops)
 
         self._set_current_homing(homing_axes, pre_homing=True)
+        self._reset_endstop_states(endstops)
 
         hmove.homing_move(homepos, hi.speed)
 
@@ -316,12 +325,7 @@ class Homing:
                     rp - ad * retract_r for rp, ad in zip(retractpos, axes_d)
                 ]
                 self.toolhead.set_position(startpos)
-                print_time = self.toolhead.get_last_move_time()
-                for endstop in endstops:
-                    # re-querying a tmc endstop seems to reset the state
-                    # otherwise it triggers almost immediately upon second home
-                    # this seems to be an adequate substitute for a 2 second dwell.
-                    endstop[0].query_endstop(print_time)
+                self._reset_endstop_states(endstops)
                 hmove = HomingMove(self.printer, endstops)
                 hmove.homing_move(homepos, hi.second_homing_speed)
                 try:


### PR DESCRIPTION
CoreXY homing currently requires a delay between axes to avoid an early trigger when homing the second axis. The way it is done now is by having a `home_current` that is different from `run_current` to induce the delay.

This change clears the TMC endstop states before homing each rail so that when `home_current` and `run_current` is the same, there is no dwell and also no early trigger on the second axis. The effect is that sensorless homing in this specific case becomes faster.

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
