### PR TITLE
bugfix: Make user-plugins work with package directories

### DIFF
--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -152,14 +152,16 @@ class Printer:
             extras_py_dirname
         )
         found_in_plugins = os.path.exists(plugins_py_name)
-        if not found_in_extras and not found_in_plugins:
+        found_in_plugins_dir = os.path.exists(plugins_py_dirname)
+
+        if not any([found_in_extras, found_in_plugins, found_in_plugins_dir]):
             if default is not configfile.sentinel:
                 return default
             raise self.config_error("Unable to load module '%s'" % (section,))
 
         if (
             found_in_extras
-            and found_in_plugins
+            and (found_in_plugins or found_in_plugins_dir)
             and not get_danger_options().allow_plugin_override
         ):
             raise self.config_error(
@@ -169,6 +171,12 @@ class Printer:
         if found_in_plugins:
             mod_spec = importlib.util.spec_from_file_location(
                 "extras." + module_name, plugins_py_name
+            )
+            mod = importlib.util.module_from_spec(mod_spec)
+            mod_spec.loader.exec_module(mod)
+        elif found_in_plugins_dir:
+            mod_spec = importlib.util.spec_from_file_location(
+                "plugins." + module_name, plugins_py_dirname
             )
             mod = importlib.util.module_from_spec(mod_spec)
             mod_spec.loader.exec_module(mod)


### PR DESCRIPTION
Make the user-plugins system work with plugins that come as a package, for example the Klipper Shake&Tune plugin.

Testing: Installed Shake&Tune, move the directory from `extras/` to `plugins/`. Without the fix the plugin could no longer be found.
```bash
pi@uku:~/klipper/klippy $ ls -laR plugins/shaketune/
plugins/shaketune/:
total 56
drwxr-xr-x 6 pi pi 4096 Jul 29 20:53 .
drwxr-xr-x 7 pi pi 4096 Jul 29 20:53 ..
drwxr-xr-x 3 pi pi 4096 Jul 29 20:53 commands
-rw-r--r-- 1 pi pi 4245 Jun 19 19:15 dummy_macros.cfg
drwxr-xr-x 3 pi pi 4096 Jul 29 20:53 graph_creators
drwxr-xr-x 3 pi pi 4096 Jun 19 19:23 helpers
-rw-r--r-- 1 pi pi  766 Jun 14 21:58 __init__.py
drwxr-xr-x 2 pi pi 4096 Jul 29 20:53 __pycache__
-rw-r--r-- 1 pi pi 2424 Jun 14 21:58 shaketune_config.py
-rw-r--r-- 1 pi pi 4403 Jun 19 19:15 shaketune_process.py
-rw-r--r-- 1 pi pi 8141 Jul 29 20:53 shaketune.py
```

With the fix Shake&Tune would be correctly loaded.

Also verified that regular plugins still work using TMC autotune plugin:
```bash
pi@uku:~/klipper/klippy $ ls -laR plugins/*.py
lrwxrwxrwx 1 pi pi   45 Jun 12 20:41 plugins/autotune_tmc.py -> ../../../klipper_tmc_autotune/autotune_tmc.py
-rw-r--r-- 1 pi pi  179 Jun 12 18:48 plugins/__init__.py
lrwxrwxrwx 1 pi pi   48 Jun 12 20:41 plugins/motor_constants.py -> ../../../klipper_tmc_autotune/motor_constants.py
```

## Checklist

- [X] pr title makes sense
- [X] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
