### PR TITLE
bugfix/z_tilt: check if retry_result is a number before converting

### DIFF
--- a/klippy/extras/z_tilt.py
+++ b/klippy/extras/z_tilt.py
@@ -83,7 +83,7 @@ class ZAdjustStatus:
         )
 
     def check_retry_result(self, retry_result):
-        if (retry_result and int(retry_result) == 0) or retry_result == "done":
+        if (retry_result and retry_result.isdigit() and int(retry_result) == 0) or retry_result == "done":
             self.applied = True
         return retry_result
 

--- a/klippy/extras/z_tilt_ng.py
+++ b/klippy/extras/z_tilt_ng.py
@@ -105,7 +105,7 @@ class ZAdjustStatus:
         )
 
     def check_retry_result(self, retry_result):
-        if (retry_result and int(retry_result) == 0) or retry_result == "done":
+        if (retry_result and retry_result.isdigit() and int(retry_result) == 0) or retry_result == "done":
             self.applied = True
         return retry_result
 


### PR DESCRIPTION
```python
>>> done2
'done'
>>> (done2 and int(done2) == 0) or done2 == "done"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: invalid literal for int() with base 10: 'done'
```

## Checklist

- [ ] pr title makes sense
- [ ] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
