### PR TITLE
Replaced default filament_diameter value with 1.75 in MPC docs

### DIFF
--- a/docs/MPC.md
+++ b/docs/MPC.md
@@ -47,7 +47,7 @@ filament_heat_capacity: 1.8
   This is the fan that is cooling extruded filament and the hotend. 
   Specifying "fan" will automatically use the part cooling fan.
   
-- `filament_diameter: fan`  
+- `filament_diameter: 1.75`  
   _Default Value: 1.75 (mm)_  
   This is the filament diameter.  
   


### PR DESCRIPTION
Fixed what looks like a typo in the MPC docs

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [x] added a test case if possible
- [x] if new feature, added to the readme
- [x] ci is happy and green
