### PR TITLE
Doc : add sensor_pin to belay config reference

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -5224,6 +5224,9 @@ extruder_stepper_name:
 #   example, if the config section for the secondary extruder is
 #   [extruder_stepper my_extruder_stepper], this parameter's value
 #   would be 'my_extruder_stepper'.
+sensor_pin:
+#   Input pin connected to the sensor. This parameter must be
+#   provided.
 #multiplier_high: 1.05
 #   High multiplier to set for the secondary extruder when extruding
 #   forward and Belay is compressed or when extruding backward and


### PR DESCRIPTION
_belay's Sensor_pin is missing in config reference  

## Checklist

- [ ] pr title makes sense
- [ ] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
