### PR TITLE
spi_flash: Add stm32g0b0xx to board_defs.py (#6646)

### DIFF
--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -19,6 +19,11 @@ BOARD_DEFS = {
         "spi_bus": "spi1",
         "cs_pin": "PA4",
     },
+    "btt-skr-mini-v3-b0": {
+        "mcu": "stm32g0b0xx",
+        "spi_bus": "spi1",
+        "cs_pin": "PA4",
+    },
     "flyboard-mini": {
         "mcu": "stm32f103xe",
         "spi_bus": "spi2",
@@ -124,6 +129,7 @@ BOARD_ALIASES = {
     "btt-skr-mini-e3-v1.2": BOARD_DEFS["btt-skr-mini"],
     "btt-skr-mini-e3-v2": BOARD_DEFS["btt-skr-mini"],
     "btt-skr-mini-e3-v3": BOARD_DEFS["btt-skr-mini-v3"],
+    "btt-skr-mini-e3-v3-b0": BOARD_DEFS["btt-skr-mini-v3-b0"],
     "btt-skr-mini-mz": BOARD_DEFS["btt-skr-mini"],
     "btt-skr-e3-dip": BOARD_DEFS["btt-skr-mini"],
     "btt002-v1": BOARD_DEFS["btt-skr-mini"],


### PR DESCRIPTION
Klipper PR: https://github.com/Klipper3d/klipper/pull/6646