### PR TITLE
servo: Asynchronous adjustments of servo position

### DIFF
--- a/klippy/extras/servo.py
+++ b/klippy/extras/servo.py
@@ -76,13 +76,16 @@ class PrinterServo:
     cmd_SET_SERVO_help = "Set servo angle"
 
     def cmd_SET_SERVO(self, gcmd):
-        print_time = self.printer.lookup_object("toolhead").get_last_move_time()
         width = gcmd.get_float("WIDTH", None)
         if width is not None:
-            self._set_pwm(print_time, self._get_pwm_from_pulse_width(width))
+            value = self._get_pwm_from_pulse_width(width)
         else:
             angle = gcmd.get_float("ANGLE")
-            self._set_pwm(print_time, self._get_pwm_from_angle(angle))
+            value = self._get_pwm_from_angle(angle)
+        toolhead = self.printer.lookup_object("toolhead")
+        toolhead.register_lookahead_callback(
+            (lambda pt: self._set_pwm(pt, value))
+        )
 
 
 def load_config_prefix(config):


### PR DESCRIPTION
This change follows the same approach as implemented for fan control. The change removes the move queue flushing when changing servo position, which does not appear to be necessary. This can be beneficial, for example, for WS7040-based cooling on IDEX setups where the servo can be used to control the air flow between the toolheads, with this change eliminating micro-stutters of the toolhead on servo position adjustment.

Klipper PR: https://github.com/Klipper3d/klipper/pull/6656