### PR TITLE
mainline commits sync

### DIFF
--- a/klippy/extras/smart_effector.py
+++ b/klippy/extras/smart_effector.py
@@ -69,6 +69,13 @@ class SmartEffectorEndstopWrapper:
         self.query_endstop = self.probe_wrapper.query_endstop
         self.multi_probe_begin = self.probe_wrapper.multi_probe_begin
         self.multi_probe_end = self.probe_wrapper.multi_probe_end
+        self.get_position_endstop = self.probe_wrapper.get_position_endstop
+        # Common probe implementation helpers
+        self.cmd_helper = probe.ProbeCommandHelper(
+            config, self, self.probe_wrapper.query_endstop
+        )
+        self.probe_offsets = probe.ProbeOffsetsHelper(config)
+        self.probe_session = probe.ProbeSessionHelper(config, self)
         # SmartEffector control
         control_pin = config.get("control_pin", None)
         if control_pin:

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -537,7 +537,7 @@ class GCodeIO:
         if self.is_fileinput:
             self.printer.request_exit("error_exit")
 
-    m112_r = re.compile("^(?:[nN][0-9]+)?\s*[mM]112(?:\s|$)")
+    m112_r = re.compile(r"^(?:[nN][0-9]+)?\s*[mM]112(?:\s|$)")
 
     def _process_data(self, eventtime):
         # Read input, separate by newline, and add to pending_commands

--- a/src/stm32/stm32g4.c
+++ b/src/stm32/stm32g4.c
@@ -104,7 +104,7 @@ enable_clock_stm32g4(void)
     RCC->CR |= RCC_CR_PLLON;
 
     // Enable 48Mhz USB clock using clock recovery
-    if (CONFIG_USBSERIAL) {
+    if (CONFIG_USB) {
         RCC->CRRCR |= RCC_CRRCR_HSI48ON;
         while (!(RCC->CRRCR & RCC_CRRCR_HSI48RDY))
             ;

--- a/src/stm32/stm32l4.c
+++ b/src/stm32/stm32l4.c
@@ -96,7 +96,7 @@ enable_clock_stm32l4(void)
     RCC->CR |= RCC_CR_PLLON;
 
     // Enable 48Mhz USB clock using clock recovery
-    if (CONFIG_USBSERIAL) {
+    if (CONFIG_USB) {
         RCC->CRRCR |= RCC_CRRCR_HSI48ON;
         while (!(RCC->CRRCR & RCC_CRRCR_HSI48RDY))
             ;


### PR DESCRIPTION
- stm32: Fix setting USB clock with USB to CANbus mode on stm32g4/stm32l4
- gcode: Minor change to suppress python warning on '\s'
- smart_effector: Define get_position_endstop() wrapper

