### PR TITLE
Allow overriding the KCONFIG_CONFIG path from environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 OUT=out/
 
 # Kconfig includes
-export KCONFIG_CONFIG     := $(CURDIR)/.config
+export KCONFIG_CONFIG     ?= $(CURDIR)/.config
 -include $(KCONFIG_CONFIG)
 
 # Common command definitions


### PR DESCRIPTION
`make KCONFIG_CONFIG=/path/to/my/.config` currently works, but is verbose and requires every step to have that variable. 

Loading from the environment using `?=` (set if not already) instead of `:=` (simple assignment) allows easier scripting

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
