### PR TITLE
Revert "smart_effector: Define get_position_endstop() wrapper"

### DIFF
--- a/klippy/extras/smart_effector.py
+++ b/klippy/extras/smart_effector.py
@@ -69,13 +69,6 @@ class SmartEffectorEndstopWrapper:
         self.query_endstop = self.probe_wrapper.query_endstop
         self.multi_probe_begin = self.probe_wrapper.multi_probe_begin
         self.multi_probe_end = self.probe_wrapper.multi_probe_end
-        self.get_position_endstop = self.probe_wrapper.get_position_endstop
-        # Common probe implementation helpers
-        self.cmd_helper = probe.ProbeCommandHelper(
-            config, self, self.probe_wrapper.query_endstop
-        )
-        self.probe_offsets = probe.ProbeOffsetsHelper(config)
-        self.probe_session = probe.ProbeSessionHelper(config, self)
         # SmartEffector control
         control_pin = config.get("control_pin", None)
         if control_pin:


### PR DESCRIPTION
This reverts commit 82b779a476cd6bf550d6bde53c4544e141f2318e.

https://github.com/DangerKlippers/danger-klipper/issues/363
