### PR TITLE
[safe_z_home] - home_y_before_x

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -59,7 +59,7 @@ serial:
 #   reset itself. The default is 'arduino' if the micro-controller
 #   communicates over a serial port, 'command' otherwise.
 #is_non_critical: False
-#   Setting this to True will allow the mcu to be disconnected and 
+#   Setting this to True will allow the mcu to be disconnected and
 #   reconnected at will without errors. Helpful for USB-accelerometer boards
 #   and USB-probes
 ```
@@ -1383,12 +1383,12 @@ extended [G-Code command](G-Codes.md#z_tilt) becomes available.
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
 #min_horizontal_move_z: 1.0
-#   minimum value for horizontal move z 
+#   minimum value for horizontal move z
 #   (only used when adaptive_horizontal_move_z is True)
 #adaptive_horizontal_move_z: False
 #   if we should adjust horizontal move z after the first adjustment round,
 #   based on error.
-#   when set to True, initial horizontal_move_z is the config value, 
+#   when set to True, initial horizontal_move_z is the config value,
 #   subsequent iterations will set horizontal_move_z to
 #   the ceil of error, or min_horizontal_move_z - whichever is greater.
 #retries: 0
@@ -1506,12 +1506,12 @@ Where x is the 0, 0 point on the bed
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
 #min_horizontal_move_z: 1.0
-#   minimum value for horizontal move z 
+#   minimum value for horizontal move z
 #   (only used when adaptive_horizontal_move_z is True)
 #adaptive_horizontal_move_z: False
 #   if we should adjust horizontal move z after the first adjustment round,
 #   based on error.
-#   when set to True, initial horizontal_move_z is the config value, 
+#   when set to True, initial horizontal_move_z is the config value,
 #   subsequent iterations will set horizontal_move_z to
 #   the ceil of error, or min_horizontal_move_z - whichever is greater.
 #max_adjust: 4
@@ -1609,6 +1609,8 @@ home_xy_position:
 #move_to_previous: False
 #   When set to True, the X and Y axes are reset to their previous
 #   positions after Z axis homing. The default is False.
+#home_y_before_x: False
+#  # If True, the Y axis will home first. The default is False.
 ```
 
 ### [homing_override]

--- a/docs/Danger_Features.md
+++ b/docs/Danger_Features.md
@@ -7,6 +7,7 @@
 - [`[exclude_object]`](./Config_Reference.md#exclude_object) is enabled by default. Use `[exclude_object] enable_exclude_object: False` to disable it
 
 ## Additional configuration options
+
 - [`[mcu] is_non_critical`](./Config_Reference.md#mcu) enables marking of an mcu as optional - it can be freely disconnected and connected at will. (useful for MCU-based accelerometer boards, mcu-based probes that shut down in hot chambers, etc...)
 - [`[danger_options]`](./Config_Reference.md#danger-options) - New configuration options to adjust klipper values that were previously hidden
 - Additional kinematics versions enabled per-axis acceleration, see [limited_cartesian](./Config_Reference.md#⚠️-cartesian-kinematics-with-limits-for-x-and-y-axes) and [limited_corexy](./Config_Reference.md#⚠️-corexy-kinematics-with-limits-for-x-and-y-axes)
@@ -33,7 +34,10 @@
 - [`[z_tilt_ng]`](./Config_Reference.md#z_tilt_ng) adds enforced 3-point z tilt calibration
 - [`[z_tilt/quad_gantry_level] increasing_threshold`](./Config_Reference.md#z_tilt) allows you to customize the allowed variation when probing multiple times
 - [`[z_tilt/quad_gantry_level] adaptive_horizontal_move_z`](./Config_Reference.md#z_tilt) adaptively decrease horizontal_move_z based on resulting error - z_tilt and QGL faster and safer!
+- [`[safe_z_home] home_y_before_x`](./Config_Reference.md#safe_z_home) let you home Y before X.
+
 ## Heaters, Fans, and PID changes
+
 - [Model Predictive Control](./MPC.md) is an advanced temperature control method that offers an alternative to traditional PID control.
 - [Velocity PID](./PID.md) can be more accurate than positional PID, but is more susceptible to noisy sensors and may require larger smoothing times
 - [`PID_PROFILE [LOAD/SAVE]`](./G-Codes.md#pid_profile) allows you to calibrate and save PID profiles at multiple temperatures and fan speeds, and later restore them. With some clever macros, automatic per-material pid tuning is within reach!
@@ -52,6 +56,7 @@
 - New [`RELOAD_GCODE_MACROS`](./G-Codes.md#reload_gcode_macros) G-Code command to reload `[gcode_macro]` templates without requiring a restart.
 
 ## [Plugins](./Plugins.md)
+
 Extend your Danger Klipper installation with custom plugins.
 
 Your python plugins can now extend [`klippy/extras`](https://github.com/DangerKlippers/danger-klipper/tree/master/klippy/extras) adding new modules to klipper without causing updates to fail due to a "dirty" git tree.

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -4,18 +4,22 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
-
 class SafeZHoming:
     def __init__(self, config):
         self.printer = config.get_printer()
         x_pos, y_pos = config.getfloatlist("home_xy_position", count=2)
         self.home_x_pos, self.home_y_pos = x_pos, y_pos
+
         self.z_hop = config.getfloat("z_hop", default=0.0)
         self.z_hop_speed = config.getfloat("z_hop_speed", 15.0, above=0.0)
+
         zconfig = config.getsection("stepper_z")
         self.max_z = zconfig.getfloat("position_max", note_valid=False)
+
         self.speed = config.getfloat("speed", 50.0, above=0.0)
         self.move_to_previous = config.getboolean("move_to_previous", False)
+        self.home_y_before_x = config.getboolean("home_y_before_x", False)
+
         self.printer.load_object(config, "homing")
         self.gcode = self.printer.lookup_object("gcode")
         self.prev_G28 = self.gcode.register_command("G28", None)
@@ -55,15 +59,18 @@ class SafeZHoming:
         if not need_x and not need_y and not need_z:
             need_x = need_y = need_z = True
 
-        # Home XY axes if necessary
-        new_params = {}
-        if need_x:
-            new_params["X"] = "0"
-        if need_y:
-            new_params["Y"] = "0"
-        if new_params:
-            g28_gcmd = self.gcode.create_gcode_command("G28", "G28", new_params)
-            self.prev_G28(g28_gcmd)
+        if need_x or need_y:
+            if self.home_y_before_x:
+                axis_order = "yx"
+            else:
+                axis_order = "xy"
+            for axis in axis_order:
+                if axis == "x" and need_x:
+                    g28_gcmd = self.gcode.create_gcode_command("G28", "G28", {"X": "0"})
+                    self.prev_G28(g28_gcmd)
+                elif axis == "y" and need_y:
+                    g28_gcmd = self.gcode.create_gcode_command("G28", "G28", {"Y": "0"})
+                    self.prev_G28(g28_gcmd)
 
         # Home Z axis if necessary
         if need_z:
@@ -75,12 +82,15 @@ class SafeZHoming:
                 or "y" not in kin_status["homed_axes"]
             ):
                 raise gcmd.error("Must home X and Y axes first")
+
             # Move to safe XY homing position
             prevpos = toolhead.get_position()
             toolhead.manual_move([self.home_x_pos, self.home_y_pos], self.speed)
+
             # Home Z
             g28_gcmd = self.gcode.create_gcode_command("G28", "G28", {"Z": "0"})
             self.prev_G28(g28_gcmd)
+
             # Perform Z Hop again for pressure-based probes
             if self.z_hop:
                 pos = toolhead.get_position()
@@ -88,6 +98,7 @@ class SafeZHoming:
                     toolhead.manual_move(
                         [None, None, self.z_hop], self.z_hop_speed
                     )
+
             # Move XY back to previous positions
             if self.move_to_previous:
                 toolhead.manual_move(prevpos[:2], self.speed)

--- a/test/klippy/safe_z_home.cfg
+++ b/test/klippy/safe_z_home.cfg
@@ -1,0 +1,127 @@
+# Test config for z_tilt and quad_gantry_level
+[stepper_x]
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PE5
+position_endstop: 0
+position_max: 250
+homing_speed: 50
+
+[stepper_y]
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PJ1
+position_endstop: 0
+position_max: 250
+homing_speed: 50
+
+[stepper_z]
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PD3
+position_endstop: 0.5
+position_max: 250
+
+[stepper_z1]
+step_pin: PC1
+dir_pin: PC3
+enable_pin: !PC7
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PD2
+
+[stepper_z2]
+step_pin: PH1
+dir_pin: PH0
+enable_pin: !PA1
+microsteps: 16
+rotation_distance: 8
+
+[stepper_z3]
+step_pin: PE3
+dir_pin: PG5
+microsteps: 16
+rotation_distance: 8
+
+[quad_gantry_level]
+gantry_corners:
+    -55,-7
+    305, 320
+points:
+    25,0
+    25,200
+    225,200
+    225,0
+
+[z_tilt]
+z_positions:
+    -55,-7
+    -55,320
+    305,-7
+    305,320
+points:
+    50,50
+    50,195
+    195,195
+    195,50
+increasing_threshold: 0.001
+
+[bed_tilt]
+points:
+    50,50
+    50,195
+    195,195
+    195,50
+
+[extruder]
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 33.5
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PB4
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK5
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 250
+
+[heater_bed]
+heater_pin: PH5
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK6
+control: watermark
+min_temp: 0
+max_temp: 130
+
+[safe_z_home]
+home_xy_position: 100, 100
+home_y_before_x: True
+
+[probe]
+pin: PH6
+z_offset: 1.15
+
+[mcu]
+serial: /dev/ttyACM0
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100

--- a/test/klippy/safe_z_home.test
+++ b/test/klippy/safe_z_home.test
@@ -1,0 +1,10 @@
+# Test case for safe_z_home
+CONFIG safe_z_home.cfg
+DICTIONARY atmega2560.dict
+
+# Start by homing the printer.
+G28
+G1 Z5 X10 Y10 F6000
+M400
+GET_POSITION
+


### PR DESCRIPTION
New [safe_z_home] parameter to let you invert the XY homing order. 

The idea is from the `beacon.py` module, so thanks @dalegaard @mattthebaker

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [x] added a test case if possible
- [x] if new feature, added to the readme
- [ ] ci is happy and green
