### PR TITLE
make homing constants configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ See the [Danger Features document](https://dangerklipper.io/Danger_Features.html
 
 - [core: action_log](https://github.com/DangerKlippers/danger-klipper/pull/367)
 
+- [danger_options: configurable homing constants](https://github.com/DangerKlippers/danger-klipper/pull/378)
+
 If you're feeling adventurous, take a peek at the extra features in the bleeding-edge-v2 branch [feature documentation](docs/Bleeding_Edge.md)
 and [feature configuration reference](docs/Config_Reference_Bleeding_Edge.md):
 

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -111,8 +111,16 @@ A collection of DangerKlipper-specific system options
 #   This allows to set extra flush time (in seconds). Under certain conditions,
 #   a low value will result in an error if message is not get flushed, a high value
 #   (0.250) will result in homing/probing latency. The default is 0.250
+#homing_start_delay: 0.001
+#   How long to dwell before beginning a drip move for homing
+#endstop_sample_time: 0.000015
+#   How often the MCU should sample the endstop state
+#endstop_sample_count: 4
+#   How many times we should check the endstop state when homing
+#   Unless your endstop is noisy and unreliable, you should be able to lower this to 1
 
-# Logging options
+
+# Logging options:
 
 #minimal_logging: False
 #   Set all log parameters log options to False. The default is False.

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -5,15 +5,21 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
 from . import probe
+from extras.danger_options import get_danger_options
 
 SIGNAL_PERIOD = 0.020
 MIN_CMD_TIME = 5 * SIGNAL_PERIOD
 
 TEST_TIME = 5 * 60.0
 RETRY_RESET_TIME = 1.0
-ENDSTOP_REST_TIME = 0.001
-ENDSTOP_SAMPLE_TIME = 0.000015
-ENDSTOP_SAMPLE_COUNT = 4
+
+
+# ENDSTOP_REST_TIME = 0.001
+# ENDSTOP_SAMPLE_TIME = 0.000015
+# ENDSTOP_SAMPLE_COUNT = 4
+ENDSTOP_REST_TIME = get_danger_options().homing_start_delay
+ENDSTOP_SAMPLE_TIME = get_danger_options().endstop_sample_time
+ENDSTOP_SAMPLE_COUNT = get_danger_options().endstop_sample_count
 
 Commands = {
     "pin_down": 0.000650,

--- a/klippy/extras/danger_options.py
+++ b/klippy/extras/danger_options.py
@@ -44,6 +44,15 @@ class DangerOptions:
         self.bgflush_extra_time = config.getfloat(
             "bgflush_extra_time", 0.250, minval=0.0
         )
+        self.homing_start_delay = config.getfloat(
+            "homing_start_delay", 0.001, minval=0.0
+        )
+        self.endstop_sample_time = config.getfloat(
+            "endstop_sample_time", 0.000015, minval=0
+        )
+        self.endstop_sample_count = config.getint(
+            "endstop_sample_count", 4, minval=1
+        )
 
         if self.minimal_logging:
             self.log_statistics = False

--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -7,9 +7,12 @@ import math
 import logging
 from extras.danger_options import get_danger_options
 
-HOMING_START_DELAY = 0.001
-ENDSTOP_SAMPLE_TIME = 0.000015
-ENDSTOP_SAMPLE_COUNT = 4
+# HOMING_START_DELAY = 0.001
+# ENDSTOP_SAMPLE_TIME = 0.000015
+# ENDSTOP_SAMPLE_COUNT = 4
+HOMING_START_DELAY = get_danger_options().homing_start_delay
+ENDSTOP_SAMPLE_TIME = get_danger_options().endstop_sample_time
+ENDSTOP_SAMPLE_COUNT = get_danger_options().endstop_sample_count
 
 
 # Return a completion that completes when all completions in a list complete

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -417,6 +417,10 @@ class Printer:
 
 def import_test():
     # Import all optional modules (used as a build test)
+    from extras import danger_options
+    from unittest import mock
+
+    danger_options.DANGER_OPTIONS = mock.Mock()
     dname = os.path.dirname(__file__)
     for mname in ["extras", "kinematics"]:
         for fname in os.listdir(os.path.join(dname, mname)):


### PR DESCRIPTION
Makes the homing constants, 
`HOMING_START_DELAY`, `ENDSTOP_SAMPLE_TIME`, and `ENDSTOP_SAMPLE_COUNT` configurable from danger_options

lowering `ENDSTOP_SAMPLE_COUNT` to 1 should likely resolve some probing drift some users have been observing

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [x] if new feature, added to the readme
- [ ] ci is happy and green
