### PR TITLE
delayed_gcode: make UPDATE_DELAYED_GCODE safe for klippy:ready handlers

### DIFF
--- a/klippy/extras/delayed_gcode.py
+++ b/klippy/extras/delayed_gcode.py
@@ -53,7 +53,9 @@ class DelayedGcode:
         self.duration = gcmd.get_float("DURATION", minval=0.0)
         if self.inside_timer:
             self.repeat = self.duration != 0.0
-        else:
+        elif self.timer_handler is not None:
+            # Update the timer if it has already been created. A klippy:ready
+            # handler might call this method before that happened.
             waketime = self.reactor.NEVER
             if self.duration:
                 waketime = self.reactor.monotonic() + self.duration


### PR DESCRIPTION
When another klippy:ready handler executes UPDATE_DELAYED_GCODE before DelayedGcode's ready handler runs, then self.timer_handler is None, causing the update_timer to fail.

This actually happened to me with moonraker-timelapse, whose Moonraker plugin executes GCode once Klippy is ready.

I also submitted this to Klipper a while ago (https://github.com/Klipper3d/klipper/pull/6631).

## Checklist

- [ ] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [x] if new feature, added to the readme
- [ ] ci is happy and green
