### PR TITLE
Autodetect Beacon for homing z

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ See the [Danger Features document](https://dangerklipper.io/Danger_Features.html
 
 - [danger_options: configurable homing constants](https://github.com/DangerKlippers/danger-klipper/pull/378)
 
+- [Homing: autodetect if beacon is used for z-homing and set the retract_dist to 0](https://github.com/DangerKlippers/danger-klipper/pull/383)
+
 If you're feeling adventurous, take a peek at the extra features in the bleeding-edge-v2 branch [feature documentation](docs/Bleeding_Edge.md)
 and [feature configuration reference](docs/Config_Reference_Bleeding_Edge.md):
 

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -329,6 +329,7 @@ max_z_accel:
 # The stepper_z section is used to describe the stepper controlling
 # the Z axis in a cartesian robot.
 [stepper_z]
+#homing_retract_dist: 5.0 by default, if you are using beacon (the beacon module is installed and probe:z_virtual_endstop is used)
 ```
 
 ### ⚠️ Cartesian Kinematics with limits for X and Y axes

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -421,6 +421,13 @@ class PrinterRail:
             endstop_pin is not None and ":virtual_endstop" in endstop_pin
         )
 
+        endstop_is_beacon = endstop_pin is not None and (
+            endstop_pin == "probe:z_virtual_endstop"
+            and config.get_printer().load_object(config, "beacon", None) is not None
+        )
+
+        default_homing_retract_dist = 0.0 if endstop_is_beacon else 5.0
+
         # Axis range
         if need_position_minmax:
             self.position_min = config.getfloat("position_min", 0.0)
@@ -447,7 +454,7 @@ class PrinterRail:
             "homing_retract_speed", self.homing_speed, above=0.0
         )
         self.homing_retract_dist = config.getfloat(
-            "homing_retract_dist", 5.0, minval=0.0
+            "homing_retract_dist", default_homing_retract_dist, minval=0.0
         )
         self.homing_positive_dir = config.getboolean(
             "homing_positive_dir", None


### PR DESCRIPTION
Automatically detect beacon for z-homing (like autodetecting sensorless homing) and set the appropriate settings by default to make sure users who dont read the doc fully dont put in wrong settings and to clean up the config/make it easier for everyone else

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [x] if new feature, added to the readme
- [x] ci is happy and green
