### PR TITLE
Trust the user on the print_radius for delta kinematics

### DIFF
--- a/klippy/kinematics/delta.py
+++ b/klippy/kinematics/delta.py
@@ -114,14 +114,7 @@ class DeltaKinematics:
 
         self.slow_xy2 = ratio_to_xy(SLOW_RATIO) ** 2
         self.very_slow_xy2 = ratio_to_xy(2.0 * SLOW_RATIO) ** 2
-        self.max_xy2 = (
-            min(
-                print_radius,
-                min_arm_length - radius,
-                ratio_to_xy(4.0 * SLOW_RATIO),
-            )
-            ** 2
-        )
+        self.max_xy2 = print_radius ** 2
         max_xy = math.sqrt(self.max_xy2)
         logging.info(
             "Delta max build radius %.2fmm (moves slowed past %.2fmm"


### PR DESCRIPTION
In current versions of (danger)-klipper, the configured `print_radius` on a delta printer is just silently ignored when it's larger than `arm_length - delta_radius`. 

While points beyond that radius might not be useful for actual print moves, I have a klicky-style probe that I want the printer to pick up outside of the "reasonable" build volume, which was formerly prevented by the above issue.

I tested the committed code on my delta printer and it solves my issue. Additionally I actively tried running it into "unreachable" territory (i.e. to the point where one of the arms would have to be horizontal and the stepper moving at infinite speed, and beyond) and found that klipper safely shuts down, without excessive movement etc.


## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green