### PR TITLE
Don't consider included options conflicting if they are the same value

### DIFF
--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -573,11 +573,15 @@ class PrinterConfig:
         for section in self.autosave.fileconfig.sections():
             for option in self.autosave.fileconfig.options(section):
                 if config.fileconfig.has_option(section, option):
-                    msg = (
-                        "SAVE_CONFIG section '%s' option '%s' conflicts "
-                        "with included value" % (section, option)
-                    )
-                    raise gcode.error(msg)
+                    # They conflict only if they are not the same value
+                    included_value = config.fileconfig.get(section, option)
+                    autosave_value = self.autosave.fileconfig.get(section, option)
+                    if included_value != autosave_value:
+                        msg = (
+                                "SAVE_CONFIG section '%s' option '%s' value '%s' conflicts "
+                                "with included value '%s' " % (section, option, autosave_value, included_value)
+                                )
+                        raise gcode.error(msg)
 
     cmd_SAVE_CONFIG_help = "Overwrite config file and restart"
 


### PR DESCRIPTION
In order to ensure users don't get confused where an option is
really being set, SAVE_CONFIG currently checks that include
files do not set options that are being saved in the main
config file's autosave section.

However, this means you can't set, say, the control mechanism
for a heater in an include file, because it is also
part of the autosave block.

This commit changes the conflict check to only consider it a
conflict if the included value differs from the one in the
autosave block (so it is okay if both set 'control:mpc' as an
example)

Signed-off-by: Daniel Berlin <dberlin@dberlin.org>
