### PR TITLE
canbus: Add CMD_QUERY_UNASSIGNED extended response, enabling query response after id assignment

### DIFF
--- a/docs/CANBUS.md
+++ b/docs/CANBUS.md
@@ -51,7 +51,7 @@ printer and use a multi-meter to check the resistance between the CANH
 and CANL wires - it should report ~60 ohms on a correctly wired CAN
 bus.
 
-## Finding the canbus_uuid for new micro-controllers
+## ⚠️ Finding the canbus_uuid for new micro-controllers
 
 Each micro-controller on the CAN bus is assigned a unique id based on
 the factory chip identifier encoded into each micro-controller. To
@@ -61,10 +61,11 @@ powered and wired correctly, and then run:
 ~/klippy-env/bin/python ~/klipper/scripts/canbus_query.py can0
 ```
 
-If uninitialized CAN devices are detected the above command will
+If CAN devices are detected the above command will
 report lines like the following:
 ```
-Found canbus_uuid=11aa22bb33cc, Application: Klipper
+Found canbus_uuid=11aa22bb33cc, Application: Klipper, Unassigned
+Found canbus_uuid=11aa22bb33cc, Application: Danger-Klipper, Assigned: 77
 ```
 
 Each device will have a unique identifier. In the above example,
@@ -73,6 +74,10 @@ Each device will have a unique identifier. In the above example,
 Note that the `canbus_query.py` tool will only report uninitialized
 devices - if Klipper (or a similar tool) configures the device then it
 will no longer appear in the list.
+
+⚠️ Note that only devices flashed with a Danger-Klipper firmware will
+respond while assigned a device node ID. Devices using a Klipper firmware
+will no longer appear in the list once configured
 
 ## Configuring Klipper
 

--- a/docs/Danger_Features.md
+++ b/docs/Danger_Features.md
@@ -15,6 +15,10 @@
 - [`[virtual_sdcard] with_subdirs`](./Config_Reference.md#virtual_sdcard) enables scanning of subdirectories for .gcode files, for the menu and M20/M23 commands
 - [`[firmware_retraction] z_hop_height`](./Config_Reference.md#firmware_retraction) adds an automatic z hop when using firmware retraction
 
+## Enhanced behavior
+
+- [`canbus_query.py`](./CANBUS.md#️-finding-the-canbus_uuid-for-new-micro-controllers) now responds with all Danger-Klipper devices, even after they've been assigned a node_id.
+
 ## New Klipper Modules
 
 - [gcode_shell_command](./G-Code_Shell_Command.md) - Execute linux commands and scripts from within Klipper

--- a/scripts/canbus_query.py
+++ b/scripts/canbus_query.py
@@ -11,9 +11,19 @@ import can
 
 CANBUS_ID_ADMIN = 0x3F0
 CMD_QUERY_UNASSIGNED = 0x00
+CMD_QUERY_UNASSIGNED_EXTENDED = 0x01
 RESP_NEED_NODEID = 0x20
+RESP_HAVE_NODEID = 0x21
 CMD_SET_KLIPPER_NODEID = 0x01
 CMD_SET_CANBOOT_NODEID = 0x11
+
+RESP_DANGER_NODEID = 0x07
+
+AppNames = {
+    CMD_SET_KLIPPER_NODEID: "Klipper",
+    RESP_DANGER_NODEID: "Danger-Klipper",
+    CMD_SET_CANBOOT_NODEID: "CanBoot",
+}
 
 
 def query_unassigned(canbus_iface):
@@ -27,7 +37,7 @@ def query_unassigned(canbus_iface):
     # Send query
     msg = can.Message(
         arbitration_id=CANBUS_ID_ADMIN,
-        data=[CMD_QUERY_UNASSIGNED],
+        data=[CMD_QUERY_UNASSIGNED, CMD_QUERY_UNASSIGNED_EXTENDED],
         is_extended_id=False,
     )
     bus.send(msg)
@@ -44,24 +54,31 @@ def query_unassigned(canbus_iface):
             msg is None
             or msg.arbitration_id != CANBUS_ID_ADMIN + 1
             or msg.dlc < 7
-            or msg.data[0] != RESP_NEED_NODEID
+            or msg.data[0] not in (RESP_NEED_NODEID, RESP_HAVE_NODEID)
         ):
             continue
         uuid = sum([v << ((5 - i) * 8) for i, v in enumerate(msg.data[1:7])])
         if uuid in found_ids:
             continue
         found_ids[uuid] = 1
-        AppNames = {
-            CMD_SET_KLIPPER_NODEID: "Klipper",
-            CMD_SET_CANBOOT_NODEID: "CanBoot",
-        }
         app_id = CMD_SET_KLIPPER_NODEID
+        node_id = None
         if msg.dlc > 7:
             app_id = msg.data[7]
+        if msg.data[0] == RESP_HAVE_NODEID:
+            node_id = app_id
+            app_id = RESP_DANGER_NODEID
         app_name = AppNames.get(app_id, "Unknown")
-        sys.stdout.write(
-            "Found canbus_uuid=%012x, Application: %s\n" % (uuid, app_name)
-        )
+        if node_id:
+            sys.stdout.write(
+                "Found canbus_uuid=%012x, Application: %s, Assigned: %02x\n"
+                % (uuid, app_name, node_id)
+            )
+        else:
+            sys.stdout.write(
+                "Found canbus_uuid=%012x, Application: %s, Unassigned\n"
+                % (uuid, app_name)
+            )
     sys.stdout.write(
         "Total %d uuids found\n"
         % (

--- a/src/generic/canserial.c
+++ b/src/generic/canserial.c
@@ -99,14 +99,12 @@ console_sendf(const struct command_encoder *ce, va_list args)
     }
 
     // Generate message
-    uint32_t msglen = command_encode_and_frame(&CanData.transmit_buf[tmax]
-                                               , ce, args);
+    uint32_t msglen = command_encode_and_frame(&CanData.transmit_buf[tmax], ce, args);
 
     // Start message transmit
     CanData.transmit_max = tmax + msglen;
     canserial_notify_tx();
 }
-
 
 /****************************************************************
  * CAN "admin" command handling
@@ -114,9 +112,14 @@ console_sendf(const struct command_encoder *ce, va_list args)
 
 // Available commands and responses
 #define CANBUS_CMD_QUERY_UNASSIGNED 0x00
+#define CANBUS_CMD_QUERY_EXTENDED 0x01
 #define CANBUS_CMD_SET_KLIPPER_NODEID 0x01
 #define CANBUS_CMD_REQUEST_BOOTLOADER 0x02
+
+#define CANBUS_RESP_KLIPPER_NODEID 0x01
+#define CANBUS_RESP_DANGER_NODEID 0x11
 #define CANBUS_RESP_NEED_NODEID 0x20
+#define CANBUS_RESP_HAVE_NODEID 0x21
 
 // Helper to verify a UUID in a command matches this chip's UUID
 static int
@@ -143,14 +146,29 @@ can_decode_nodeid(int nodeid)
 static void
 can_process_query_unassigned(struct canbus_msg *msg)
 {
-    if (CanData.assigned_id)
+    uint8_t is_extended_query = // Danger-Klipper addition
+        msg->dlc > 1
+            ? msg->data[1] & CANBUS_CMD_QUERY_EXTENDED
+            : 0;
+    if (CanData.assigned_id && !is_extended_query)
         return;
     struct canbus_msg send;
     send.id = CANBUS_ID_ADMIN_RESP;
     send.dlc = 8;
     send.data[0] = CANBUS_RESP_NEED_NODEID;
     memcpy(&send.data[1], CanData.uuid, sizeof(CanData.uuid));
-    send.data[7] = CANBUS_CMD_SET_KLIPPER_NODEID;
+
+    if (is_extended_query) {
+        if (CanData.assigned_id) {
+            send.data[0] = CANBUS_RESP_HAVE_NODEID;
+            send.data[7] = can_get_nodeid();
+        } else {
+            send.data[7] = CANBUS_RESP_DANGER_NODEID;
+        }
+    } else {
+        send.data[7] = CANBUS_RESP_KLIPPER_NODEID;
+    }
+
     // Send with retry
     for (;;) {
         int ret = canbus_send(&send);


### PR DESCRIPTION
msg=[0x00] responds with a klipper-compatible response
- Response is [0x20, canbus_uuid, app_id] (0x01 for klipper, 0x11 for Canboot)

msg=[0x00, 0x01] enables extended responses.
- "Normal" Klipper devices will ignore this extended bit completely
- Danger-Klipper devices will now respond regardless of whether the device is already assigned a node_id. Responses are generally klipper-compatible, although in the odd case that someone manually sends [0x00, 0x01] from Klipper, the app_name will probably show as "Unknown", unless it happens to be 0x01 or 0x11. If the device is already assigned, the response will be ignored completely
    - Response: [0x20, canbus_uuid, 0x07] 0x07 being a new Danger-Klipper app_id
    - Response: [0x21, canbus_uuid, node_id] 0x21 is a new "RESP_HAVE_NODEID" value

This also updates scripts/canbus_query.py to use the extended query, now
 listing
    Found canbus_uuid=%012x, Application: Danger-Klipper, Unassigned
    Found canbus_uuid=%012x, Application: Danger-Klipper, Assigned: 05

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
  - [x] Tested over U2C
  - [x] Tested with Can-Bridge
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
