### PR TITLE
trad_rack: various small updates

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1642,10 +1642,14 @@ selector motor will be enabled if it isn't already.
 not been loaded.
 
 #### TR_RESUME
-`TR_RESUME`: Retries loading the last lane, loads the next filament
-into the toolhead, and resumes the print. The user will be prompted
-to use this command if Trad Rack has paused the print due to a failed
-load or unload.
+`TR_RESUME`: Completes necessary actions for Trad Rack to recover
+(and/or checks that Trad Rack is ready to continue), then resumes the
+print if all of those actions complete successfully. For example, if
+the print was paused due to a failed toolchange, then this command
+would retry the toolchange and then resume the print if the toolchange
+completes successfully. You will be prompted to use this command if
+Trad Rack has paused the print and requires user interaction or
+confirmation before attempting to recover and resume.
 
 #### TR_LOCATE_SELECTOR
 `TR_LOCATE_SELECTOR`: Ensures the position of Trad Rack's selector is

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -571,6 +571,13 @@ The following informatin is available in the
 [trad_rack](Config_Reference.md#trad_rack) object:
 - `curr_lane`: The lane the selector is currently positioned at.
 - `active_lane`: The lane currently loaded in the toolhead.
+- `next_lane`: The next lane to load to the toolhead if a toolchange
+  is in progress.
+- `next_tool`: The next tool to load to the toolhead if a toolchange
+  is in progress (if a tool number was specified for the toolchange).
+- `tool_map`: An array of integers listing the assigned tool for each
+  lane. The tool number for a specified lane can be accessed with
+  `tool_map[<lane index>]`.
 - `selector_homed`: Whether or not the selector axis is homed.
 
 ## virtual_sdcard

--- a/klippy/extras/trad_rack.py
+++ b/klippy/extras/trad_rack.py
@@ -17,12 +17,16 @@ FIL_DRIVER_STEPPER_NAME = "stepper_tr_fil_driver"
 
 
 class TradRack:
+    # variables saved with save_variables
     VARS_CALIB_BOWDEN_LOAD_LENGTH = "tr_calib_bowden_load_length"
     VARS_CALIB_BOWDEN_UNLOAD_LENGTH = "tr_calib_bowden_unload_length"
     VARS_CONFIG_BOWDEN_LENGTH = "tr_config_bowden_length"
     VARS_TOOL_STATUS = "tr_state_tool_status"
     VARS_HEATER_TARGET = "tr_last_heater_target"
     VARS_ACTIVE_LANE = "tr_active_lane"
+
+    # gcode states
+    GCODE_STATE_TOOLCHANGE = "TR_TOOLCHANGE_STATE"
 
     def __init__(self, config):
         self.printer = config.get_printer()
@@ -223,8 +227,8 @@ class TradRack:
         self.curr_lane = None  # which lane the selector is positioned at
         self.active_lane = None  # lane currently loaded in the toolhead
         self.retry_lane = None  # lane to reload before resuming
-        self.retry_tool = None  # tool to load a lane from before resuming
-        self.next_lane = None  # next lane to load to toolhead if resuming
+        self.next_lane = None  # next lane to load to toolhead
+        self.next_tool = None  # next tool to load to toolhead
         self.servo_raised = None
         self.lanes_unloaded = [False] * self.lane_count
         self.bowden_load_calibrated = False
@@ -238,6 +242,8 @@ class TradRack:
         self.ignore_next_unload_length = False
         self.last_heater_target = 0.0
         self.tr_next_generator = None
+        self.selector_pos_uncertain = False
+        self.variables = None
 
         # resume variables
         self.resume_callbacks = {
@@ -455,14 +461,13 @@ class TradRack:
         )
 
     def handle_runout(self, eventtime):
-        # pause
+        # send pause command
         pause_resume = self.printer.lookup_object("pause_resume")
         pause_resume.send_pause_command()
         # self.printer.get_reactor().pause(eventtime + self.pause_delay)
-        self._send_pause()
 
-        # set up resume callback
-        self._set_up_resume("runout", {})
+        # set up resume callback and run pause gcode
+        self._set_up_resume_and_pause("runout", {})
 
         # note runout
         self.runout_lane = self.active_lane
@@ -487,7 +492,9 @@ class TradRack:
     def cmd_TR_HOME(self, gcmd):
         # check for filament in the selector
         if self._query_selector_sensor():
-            raise self.gcode.error("Cannot home with filament in selector")
+            raise self.printer.command_error(
+                "Cannot home with filament in selector"
+            )
 
         # reset current lane
         self.curr_lane = None
@@ -508,6 +515,9 @@ class TradRack:
             self.printer.lookup_object("stepper_enable").motor_off()
             raise
 
+        # unmark selector position as uncertain
+        self.selector_pos_uncertain = False
+
     cmd_TR_GO_TO_LANE_help = "Move Trad Rack's selector to a filament lane"
 
     def cmd_TR_GO_TO_LANE(self, gcmd):
@@ -519,7 +529,7 @@ class TradRack:
 
     def cmd_TR_LOAD_LANE(self, gcmd):
         lane = gcmd.get_int("LANE", None)
-        self._load_lane(lane, gcmd, gcmd.get_int("RESET_SPEED", 1), True)
+        self._load_lane(lane, gcmd.get_int("RESET_SPEED", 1), True)
         self.lanes_dead[lane] = False
 
     cmd_TR_LOAD_TOOLHEAD_help = "Load filament from Trad Rack into the toolhead"
@@ -544,7 +554,8 @@ class TradRack:
                     " continue.".format(tool=str(tool))
                 )
 
-                # set up resume callback
+                # set up resume callback and pause the print
+                # (and wait for user to resume)
                 resume_kwargs = {
                     "condition": (
                         lambda t=tool: self.default_lanes[t] is not None
@@ -555,17 +566,13 @@ class TradRack:
                         " lane to tool %d, then use TR_RESUME." % tool
                     ),
                 }
-                self._set_up_resume("check condition", resume_kwargs)
-
-                # pause and wait for user to resume
-                self._send_pause()
+                self._set_up_resume_and_pause("check condition", resume_kwargs)
                 return
 
         # load toolhead
         try:
             self._load_toolhead(
                 lane,
-                gcmd,
                 tool,
                 gcmd.get_float("MIN_TEMP", 0.0, minval=0.0),
                 gcmd.get_float("EXACT_TEMP", 0.0, minval=0.0),
@@ -580,18 +587,18 @@ class TradRack:
                 ),
                 exc_info=True,
             )
-            # set up resume callback
-            self._set_up_resume("load toolhead", {})
 
-            # pause and wait for user to resume
-            self._send_pause()
+            # set up resume callback and pause the print
+            # (and wait for user to resume)
+            self._set_up_resume_and_pause("load toolhead", {})
         except SelectorNotHomedError:
             gcmd.respond_info(
                 "Selector not homed. Use TR_LOCATE_SELECTOR (or TR_HOME to home"
                 " the selector directly), then use TR_RESUME to continue."
             )
 
-            # set up resume callback
+            # set up resume callback and pause the print
+            # (and wait for user to resume)
             resume_kwargs = {
                 "condition": self._is_selector_homed,
                 "action": lambda g=gcmd: self.cmd_TR_LOAD_TOOLHEAD(g),
@@ -600,16 +607,12 @@ class TradRack:
                     " TR_HOME to home the selector, then use TR_RESUME."
                 ),
             }
-            self._set_up_resume("check condition", resume_kwargs)
-
-            # pause and wait for user to resume
-            self._send_pause()
+            self._set_up_resume_and_pause("check condition", resume_kwargs)
 
     cmd_TR_UNLOAD_TOOLHEAD_help = "Unload filament from the toolhead"
 
     def cmd_TR_UNLOAD_TOOLHEAD(self, gcmd):
         self._unload_toolhead(
-            gcmd,
             gcmd.get_float("MIN_TEMP", 0.0, minval=0.0),
             gcmd.get_float("EXACT_TEMP", 0.0, minval=0.0),
         )
@@ -620,7 +623,7 @@ class TradRack:
         if not gcmd.get_int("FORCE", 0):
             # check that the selector is at a lane
             if not self._can_lower_servo():
-                raise self.gcode.error(
+                raise self.printer.command_error(
                     "Selector must be moved to a lane before lowering the servo"
                 )
 
@@ -662,7 +665,7 @@ class TradRack:
         # check raw angle
         max_angle = self.servo.get_max_angle()
         if raw_angle > max_angle:
-            raise self.gcode.error(
+            raise self.printer.command_error(
                 "Raw angle is above the maximum of %.3f (corresponding to a"
                 " commanded angle of %.3f). If the servo is not rotating far"
                 " enough, try increasing maximum_pulse_width in the [%s]"
@@ -670,7 +673,7 @@ class TradRack:
                 % (max_angle, raw_to_cmd(max_angle), SERVO_NAME)
             )
         elif raw_angle < 0.0:
-            raise self.gcode.error(
+            raise self.printer.command_error(
                 "Raw angle is below the minimum of 0.0 (corresponding to a"
                 " commanded angle of %.3f). If the servo is not rotating far"
                 " enough, try decreasing minimum_pulse_width in the [%s]"
@@ -693,14 +696,22 @@ class TradRack:
 
         # check for filament in the selector
         if not self._query_selector_sensor():
-            raise self.gcode.error(
+            raise self.printer.command_error(
                 "Cannot set active lane without filament in selector"
             )
 
-        # set selector position
+        # get current selector position and lane position
         print_time = self.tr_toolhead.get_last_move_time()
         pos = self.tr_toolhead.get_position()
-        pos[0] = self.lane_positions[lane]
+        lane_pos = self.lane_positions[lane]
+
+        # mark selector position as uncertain if not homed or current position
+        # doesn't match lane position
+        if not (self._is_selector_homed() and pos[0] == lane_pos):
+            self.selector_pos_uncertain = True
+
+        # set selector position
+        pos[0] = lane_pos
         self.tr_toolhead.set_position(pos, homing_axes=(0,))
         stepper_enable = self.printer.lookup_object("stepper_enable")
         enable = stepper_enable.lookup_enable(SELECTOR_STEPPER_NAME)
@@ -709,6 +720,11 @@ class TradRack:
         # set current lane and active lane
         self.curr_lane = lane
         self._set_active_lane(lane)
+
+        # reset next lane and tool if there is no longer a pending toolchange
+        if self._is_next_toolchange_done():
+            self.next_lane = None
+            self.next_tool = None
 
         # restore extruder sync
         self._restore_extruder_sync()
@@ -733,7 +749,10 @@ class TradRack:
         self.selector_sensor.set_active(False)
         self.printer.send_event("trad_rack:reset_active_lane")
 
-    cmd_TR_RESUME_help = "Resume after a failed load or unload"
+    cmd_TR_RESUME_help = (
+        "Completes necessary actions for Trad Rack to recover and resumes the"
+        " print"
+    )
 
     def cmd_TR_RESUME(self, gcmd):
         resume_msg = None
@@ -749,10 +768,8 @@ class TradRack:
 
             # run the resume callback
             try:
-                retry_resume, resume_msg = resume_callback(
-                    gcmd, **resume_kwargs
-                )
-            except:
+                retry_resume, resume_msg = resume_callback(**resume_kwargs)
+            except self.printer.command_error:
                 # if the resume callback raised an error, add the resume back to
                 # the stack
                 self.resume_stack.append((resume_callback, resume_kwargs))
@@ -785,7 +802,7 @@ class TradRack:
                 try:
                     self._check_lane_valid(saved_active_lane)
                     self.active_lane = saved_active_lane
-                except self.gcode.error:
+                except self.printer.command_error:
                     pass
 
             if self.active_lane is None:
@@ -798,20 +815,6 @@ class TradRack:
                     " TR_RESUME to resume the print."
                 )
                 self.ignore_next_unload_length = True
-
-                # set up resume callback
-                resume_kwargs = {
-                    "condition": (
-                        lambda: self.active_lane is not None
-                        or not self._query_selector_sensor()
-                    ),
-                    "action": self._resume_act_locate_selector,
-                    "fail_msg": (
-                        "Cannot resume. Please use either TR_SET_ACTIVE_LANE or"
-                        " TR_UNLOAD_TOOLHEAD, then use TR_RESUME."
-                    ),
-                }
-                self._set_up_resume("check condition", resume_kwargs)
 
                 # set up callback to run if user takes no action
                 if self.user_wait_time != -1:
@@ -827,8 +830,20 @@ class TradRack:
                         self.user_wait_time,
                     )
 
-                # pause and wait for user to resume
-                self._send_pause()
+                # set up resume callback and pause the print
+                # (and wait for user to resume)
+                resume_kwargs = {
+                    "condition": (
+                        lambda: self.active_lane is not None
+                        or not self._query_selector_sensor()
+                    ),
+                    "action": self._resume_act_locate_selector,
+                    "fail_msg": (
+                        "Cannot resume. Please use either TR_SET_ACTIVE_LANE or"
+                        " TR_UNLOAD_TOOLHEAD, then use TR_RESUME."
+                    ),
+                }
+                self._set_up_resume_and_pause("check condition", resume_kwargs)
             else:
                 # (if the selector is homed, nothing needs to be done)
                 if not self._is_selector_homed():
@@ -859,7 +874,7 @@ class TradRack:
     )
 
     def cmd_TR_CALIBRATE_SELECTOR(self, gcmd):
-        self.tr_next_generator = self._calibrate_selector(gcmd)
+        self.tr_next_generator = self._calibrate_selector()
         next(self.tr_next_generator)
 
     cmd_TR_NEXT_help = (
@@ -876,7 +891,7 @@ class TradRack:
                 if not isinstance(e, StopIteration):
                     raise
         else:
-            raise self.gcode.error("TR_NEXT command is inactive")
+            raise self.printer.command_error("TR_NEXT command is inactive")
 
     cmd_TR_SET_HOTEND_LOAD_LENGTH_help = (
         "Sets hotend_load_length. Does not persist across restarts."
@@ -887,7 +902,9 @@ class TradRack:
         if value is None:
             adjust = gcmd.get_float("ADJUST", None)
             if adjust is None:
-                raise self.gcode.error("VALUE or ADJUST must be specified")
+                raise self.printer.command_error(
+                    "VALUE or ADJUST must be specified"
+                )
             value = max(0.0, self.hotend_load_length + adjust)
         self.hotend_load_length = value
         gcmd.respond_info("hotend_load_length: %f" % (self.hotend_load_length))
@@ -1072,13 +1089,13 @@ class TradRack:
 
     def _check_lane_valid(self, lane):
         if lane is None or lane > self.lane_count - 1 or lane < 0:
-            raise self.gcode.error("Invalid LANE")
+            raise self.printer.command_error("Invalid LANE")
 
     def _check_tool_valid(self, tool):
         try:
             self._check_lane_valid(tool)
-        except:
-            raise self.gcode.error("Invalid TOOL")
+        except self.printer.command_error:
+            raise self.printer.command_error("Invalid TOOL")
 
     def _check_selector_homed(self):
         if not self._is_selector_homed():
@@ -1088,6 +1105,28 @@ class TradRack:
         return (
             self._is_selector_homed() and self.curr_lane is not None
         ) or self._query_selector_sensor()
+
+    def _is_next_toolchange_done(self):
+        # return True if there is no pending toolchange
+        if self.next_lane is None:
+            return True
+
+        # check if an active lane is set
+        if self.active_lane is None:
+            return False
+
+        # check if active lane matches next lane
+        if self.active_lane == self.next_lane:
+            return True
+
+        # check if active lane is assigned to next tool
+        if (
+            self.next_tool is not None
+            and self.tool_map[self.active_lane] == self.next_tool
+        ):
+            return True
+
+        return False
 
     def _reset_fil_driver(self):
         self.extruder_sync_manager.reset_fil_driver()
@@ -1112,7 +1151,7 @@ class TradRack:
 
         # check for filament in the selector
         if self._query_selector_sensor():
-            raise self.gcode.error(
+            raise self.printer.command_error(
                 "Cannot change lane with filament in selector"
             )
 
@@ -1128,22 +1167,13 @@ class TradRack:
         # set current lane
         self.curr_lane = lane
 
-    def _load_lane(self, lane, gcmd, reset_speed=False, user_load=False):
+    def _load_lane(self, lane, reset_speed=False, user_load=False):
         # check lane
         self._check_lane_valid(lane)
 
         # reset lane speed
         if reset_speed:
             self.lanes_unloaded[lane] = False
-
-        # move selector
-        self._go_to_lane(lane)
-
-        # lower servo and turn the drive gear until filament is detected
-        self._lower_servo()
-        self.tr_toolhead.wait_moves()
-        if user_load:
-            gcmd.respond_info("Please insert filament in lane %d" % (lane))
 
         # load filament into the selector
         self._load_selector(lane, user_load=user_load)
@@ -1168,7 +1198,7 @@ class TradRack:
         self._raise_servo()
 
         if user_load:
-            gcmd.respond_info("Load complete")
+            self.gcode.respond_info("Load complete")
 
     def _wait_for_heater_temp(self, min_temp=0.0, exact_temp=0.0):
         # get current and target temps
@@ -1181,16 +1211,16 @@ class TradRack:
             max(min_temp, exact_temp, target_temp, self.last_heater_target)
             < min_extrude_temp
         ):
-            raise self.gcode.error(
+            raise self.printer.command_error(
                 "Extruder temperature must be set above min_extrude_temp"
             )
 
         # set temp and wait if below acceptable temp
-        min_temp = max(min_temp, min_extrude_temp)
-        if exact_temp or smoothed_temp < min_temp:
+        min_usable_temp = max(min_temp, min_extrude_temp)
+        if exact_temp or smoothed_temp < min_usable_temp:
             if exact_temp:
                 temp = save_temp = exact_temp
-            elif target_temp > min_temp:
+            elif target_temp > min_usable_temp:
                 temp = save_temp = target_temp
             else:
                 temp = max(min_temp, self.last_heater_target)
@@ -1216,7 +1246,6 @@ class TradRack:
     def _load_toolhead(
         self,
         lane,
-        gcmd,
         tool=None,
         min_temp=0.0,
         exact_temp=0.0,
@@ -1225,8 +1254,19 @@ class TradRack:
         extruder_load_length=None,
         hotend_load_length=None,
     ):
-        # keep track of lane in case of an error
+        # save gcode state
+        self.gcode.run_script_from_command(
+            "SAVE_GCODE_STATE NAME={}".format(self.GCODE_STATE_TOOLCHANGE)
+        )
+
+        # reset retry_lane
+        self.retry_lane = None
+
+        # keep track of lane in case of an error (and for status)
         self.next_lane = lane
+
+        # keep track of tool for status
+        self.next_tool = tool
 
         # check lane
         self._check_lane_valid(lane)
@@ -1244,31 +1284,26 @@ class TradRack:
         if hotend_load_length is None:
             hotend_load_length = self.hotend_load_length
 
-        # save gcode state
-        self.gcode.run_script_from_command(
-            "SAVE_GCODE_STATE NAME=TR_TOOLCHANGE_STATE"
-        )
-
         # wait for heater temp if needed
         save_temp = self._wait_for_heater_temp(min_temp, exact_temp)
 
         # disable runout detection
         self.selector_sensor.set_active(False)
 
-        # unload current lane (if filament is detected)
         if not (selector_already_loaded and self.curr_lane == lane):
+            # unload current lane (if filament is detected)
             try:
-                self._unload_toolhead(gcmd)
-            except:
+                self._unload_toolhead()
+            except self.printer.command_error:
                 self._raise_servo()
                 if self.curr_lane is None:
-                    gcmd.respond_info(
+                    self.gcode.respond_info(
                         "Failed to unload. Please either pull the filament out"
                         " of the toolhead and selector or retry with"
                         " TR_UNLOAD_TOOLHEAD, then use TR_RESUME to continue."
                     )
                 else:
-                    gcmd.respond_info(
+                    self.gcode.respond_info(
                         "Failed to unload. Please either pull the filament in"
                         " lane {lane} out of the toolhead and selector or retry"
                         " with TR_UNLOAD_TOOLHEAD, then use TR_RESUME to reload"
@@ -1286,6 +1321,20 @@ class TradRack:
                     " load"
                 )
 
+            # home if selector position is uncertain
+            if self.selector_pos_uncertain:
+                try:
+                    self.cmd_TR_HOME(
+                        self.gcode.create_gcode_command(
+                            "TR_HOME", "TR_HOME", {}
+                        )
+                    )
+                except:
+                    logging.warning(
+                        "trad_rack: Failed to home selector", exc_info=True
+                    )
+                    raise SelectorNotHomedError("Failed to home selector")
+
         # notify toolhead load started
         self.printer.send_event("trad_rack:load_started")
 
@@ -1296,17 +1345,18 @@ class TradRack:
 
         # load filament into the selector
         try:
-            self._load_selector(lane, tool=tool)
-        except:
+            selected_lane = self._load_selector(lane, tool=tool)
+        except self.printer.command_error:
             self._raise_servo()
             if tool is None:
-                gcmd.respond_info(
+                self.gcode.respond_info(
                     "Failed to load selector from lane {lane}. Use TR_RESUME to"
                     " reload lane {lane} and retry.".format(lane=str(lane))
                 )
+                self.retry_lane = lane
             else:
                 assigned_lanes = self._get_assigned_lanes(tool)
-                gcmd.respond_info(
+                self.gcode.respond_info(
                     "Failed to load selector from any of the lanes assigned to"
                     " tool {tool}: {lanes}. Use TR_LOAD_LANE LANE=&lt;lane"
                     " index&gt to reload one of these lanes, then use TR_RESUME"
@@ -1314,14 +1364,15 @@ class TradRack:
                     " TR_ASSIGN_LANE LANE=&lt;lane index&gt TOOL={tool}"
                     " beforehand.)".format(tool=tool, lanes=assigned_lanes)
                 )
-            self.retry_lane = lane
-            self.retry_tool = tool
             logging.warning("trad_rack: Failed to load selector", exc_info=True)
             raise TradRackLoadError(
                 "Failed to load toolhead. Could not load selector from lane %d"
                 % lane
             )
-        self.retry_tool = None
+
+        # update lane and next_lane in case the selector was loaded from a lane
+        # other than what was initially specified
+        lane = self.next_lane = selected_lane
 
         # move filament through the bowden tube
         self._reset_fil_driver()
@@ -1365,10 +1416,10 @@ class TradRack:
                 trigpos = hmove.homing_move(
                     pos, self.toolhead_sense_speed, probe_pos=True
                 )
-            except:
+            except self.printer.command_error:
                 self._raise_servo()
                 self.extruder_sync_manager.unsync()
-                gcmd.respond_info(
+                self.gcode.respond_info(
                     "Failed to load toolhead from lane {lane} (no trigger on"
                     " toolhead sensor). Please either pull the filament in lane"
                     " {lane} out of the toolhead and selector or use"
@@ -1408,7 +1459,7 @@ class TradRack:
             self._save_bowden_length("load", self.bowden_load_length, samples)
             if not (self.bowden_load_calibrated or reached_sensor_early):
                 self.bowden_load_calibrated = True
-                gcmd.respond_info(
+                self.gcode.respond_info(
                     "Calibrated bowden_load_length: {}".format(
                         self.bowden_load_length
                     )
@@ -1477,8 +1528,14 @@ class TradRack:
 
         # restore gcode state
         self.gcode.run_script_from_command(
-            "RESTORE_GCODE_STATE NAME=TR_TOOLCHANGE_STATE MOVE=1"
+            "RESTORE_GCODE_STATE NAME={} MOVE=1".format(
+                self.GCODE_STATE_TOOLCHANGE
+            )
         )
+
+        # reset next lane and tool
+        self.next_lane = None
+        self.next_tool = None
 
         # notify toolhead load complete
         self.printer.send_event("trad_rack:load_complete")
@@ -1486,21 +1543,35 @@ class TradRack:
     def _load_selector(self, lane, tool=None, user_load=False):
         try:
             self._do_load_selector(lane, user_load=user_load)
-        except self.gcode.error:
+        except self.printer.command_error:
             if tool is None:
                 raise
-            elif self._find_replacement_lane(lane) is None:
-                raise self.gcode.error(
-                    "Failed to load filament into selector from any of the"
-                    " lanes assigned to tool {}".format(tool)
+            else:
+                lane = self._find_replacement_lane(
+                    lane, check_runout_lane=False
                 )
+                if lane is None:
+                    raise self.printer.command_error(
+                        "Failed to load filament into selector from any of the"
+                        " lanes assigned to tool {}".format(tool)
+                    )
+        return lane
 
     def _do_load_selector(self, lane, user_load=False):
         # move selector
         self._go_to_lane(lane)
 
-        # lower servo and turn the drive gear until filament is detected
+        # lower servo
         self._lower_servo()
+        self.tr_toolhead.wait_moves()
+
+        # prompt user to insert filament
+        if user_load:
+            self.gcode.respond_info(
+                "Please insert filament in lane %d" % (lane)
+            )
+
+        # turn the drive gear until filament is detected
         self._reset_fil_driver()
         self.tr_toolhead.get_last_move_time()
         pos = self.tr_toolhead.get_position()
@@ -1514,26 +1585,26 @@ class TradRack:
         pos[1] += self.fil_homing_lengths[length_key]
         try:
             hmove.homing_move(pos, self.selector_sense_speed)
-        except:
+        except self.printer.command_error:
             self._raise_servo()
             logging.warning(
                 "trad_rack: Selector homing move failed", exc_info=True
             )
-            raise self.gcode.error(
+            raise self.printer.command_error(
                 "Failed to load filament into selector. No trigger on selector"
                 " sensor after full movement"
             )
 
     def _unload_selector(
-        self, gcmd, base_length=None, mark_calibrated=False, eject=False
+        self, base_length=None, mark_calibrated=False, eject=False
     ):
         # check for filament in selector
         if not self._query_selector_sensor():
-            gcmd.respond_info(
+            self.gcode.respond_info(
                 "No filament detected. Attempting to load selector"
             )
             self._load_selector(self.curr_lane)
-            gcmd.respond_info(
+            self.gcode.respond_info(
                 "Loaded selector. Retracting filament into module"
             )
         else:
@@ -1555,12 +1626,12 @@ class TradRack:
                     probe_pos=True,
                     triggered=False,
                 )
-            except:
+            except self.printer.command_error:
                 self._raise_servo()
                 logging.warning(
                     "trad_rack: Selector homing move failed", exc_info=True
                 )
-                raise self.gcode.error(
+                raise self.printer.command_error(
                     "Failed to unload filament from selector. Selector sensor"
                     " still triggered after full movement"
                 )
@@ -1591,7 +1662,7 @@ class TradRack:
                 )
                 if mark_calibrated:
                     self.bowden_unload_calibrated = True
-                    gcmd.respond_info(
+                    self.gcode.respond_info(
                         "Calibrated bowden_unload_length: {}".format(
                             self.bowden_unload_length
                         )
@@ -1623,19 +1694,12 @@ class TradRack:
 
     def _unload_toolhead(
         self,
-        gcmd,
         min_temp=0.0,
         exact_temp=0.0,
         force_unload=False,
         sync=False,
         eject=False,
     ):
-        # reset active lane
-        self._set_active_lane(None)
-
-        # disable runout detection
-        self.selector_sensor.set_active(False)
-
         selector_sensor_state = self._query_selector_sensor()
         toolhead_sensor_state = self._query_toolhead_sensor()
 
@@ -1650,7 +1714,7 @@ class TradRack:
         # check for faulty toolhead or selector sensor
         if not force_unload:
             if toolhead_sensor_state and not selector_sensor_state:
-                gcmd.respond_info(
+                self.gcode.respond_info(
                     "WARNING: The toolhead filament sensor is triggered but the"
                     " selector sensor is not. This may indicate that one of the"
                     " sensors is faulty or that there is a short piece of"
@@ -1660,9 +1724,12 @@ class TradRack:
 
         # check that the selector is at a lane
         if not self._can_lower_servo():
-            raise self.gcode.error(
+            raise self.printer.command_error(
                 "Selector must be moved to a lane before unloading"
             )
+
+        # disable runout detection
+        self.selector_sensor.set_active(False)
 
         # notify toolhead unload started
         self.printer.send_event("trad_rack:unload_started")
@@ -1684,6 +1751,9 @@ class TradRack:
             # unsync filament driver from extruder
             self.extruder_sync_manager.unsync()
 
+            # reset active lane
+            self._set_active_lane(None)
+
         # lower servo
         self._lower_servo(True)
 
@@ -1702,14 +1772,14 @@ class TradRack:
                 hmove.homing_move(
                     pos, self.toolhead_sense_speed, triggered=False
                 )
-            except:
+            except self.printer.command_error:
                 self._raise_servo()
                 self.extruder_sync_manager.unsync()
                 logging.warning(
                     "trad_rack: Toolhead sensor homing move failed",
                     exc_info=True,
                 )
-                raise self.gcode.error(
+                raise self.printer.command_error(
                     "Failed to unload toolhead. Toolhead sensor still triggered"
                     " after full movement"
                 )
@@ -1749,7 +1819,7 @@ class TradRack:
         mark_calibrated = not (
             self.bowden_unload_calibrated or reached_sensor_early
         )
-        self._unload_selector(gcmd, move_start - pos[1], mark_calibrated, eject)
+        self._unload_selector(move_start - pos[1], mark_calibrated, eject)
 
         # note that the current lane's buffer has been filled
         if self.curr_lane is not None:
@@ -1768,8 +1838,19 @@ class TradRack:
 
     def _send_pause(self):
         pause_resume = self.printer.lookup_object("pause_resume")
-        if not pause_resume.get_status(self.reactor.monotonic())["is_paused"]:
-            self.pause_macro.run_gcode_from_command()
+        if pause_resume.get_status(self.reactor.monotonic())["is_paused"]:
+            return
+
+        # run pause macro
+        self.pause_macro.run_gcode_from_command()
+
+        # if a toolchange is in progress, replace the PAUSE_STATE gcode state
+        # with the state from right before the toolchange was initiated
+        if not self._is_next_toolchange_done():
+            saved_states = self.printer.lookup_object("gcode_move").saved_states
+            saved_states["PAUSE_STATE"] = saved_states[
+                self.GCODE_STATE_TOOLCHANGE
+            ]
 
     def _send_resume(self, resume_msg=None):
         pause_resume = self.printer.lookup_object("pause_resume")
@@ -1791,13 +1872,21 @@ class TradRack:
         self.tool_map = list(range(self.lane_count))
         self.default_lanes = list(range(self.lane_count))
 
-    def _find_replacement_lane(self, runout_lane):
+    def _find_replacement_lane(self, runout_lane, check_runout_lane=True):
         tool = self.tool_map[runout_lane]
         pre_dead_lanes = []
+
+        # home if selector position is uncertain
+        if self.selector_pos_uncertain:
+            self.cmd_TR_HOME(
+                self.gcode.create_gcode_command("TR_HOME", "TR_HOME", {})
+            )
 
         # 1st pass - check lanes not marked as dead
         lane = (runout_lane + 1) % self.lane_count
         while True:
+            if lane == runout_lane and not check_runout_lane:
+                break
             if self.tool_map[lane] == tool:
                 if self.lanes_dead[lane]:
                     pre_dead_lanes.append(lane)
@@ -1806,7 +1895,7 @@ class TradRack:
                         self._load_selector(lane)
                         self.default_lanes[tool] = lane
                         return lane
-                    except:
+                    except self.printer.command_error:
                         self.lanes_dead[lane] = True
             if lane == runout_lane:
                 break
@@ -1819,7 +1908,7 @@ class TradRack:
                 self.lanes_dead[lane] = False
                 self.default_lanes[tool] = lane
                 return lane
-            except:
+            except self.printer.command_error:
                 pass
         return None
 
@@ -1861,20 +1950,20 @@ class TradRack:
                 lanes.append(lane)
         return lanes
 
-    def _runout_replace_filament(self, gcmd):
+    def _runout_replace_filament(self):
+        check_runout_lane = True
+
         # unload
         if self.runout_steps_done < 1:
             try:
-                self._unload_toolhead(
-                    gcmd, force_unload=True, sync=True, eject=True
-                )
-            except:
+                self._unload_toolhead(force_unload=True, sync=True, eject=True)
+                check_runout_lane = False
+            except self.printer.command_error:
                 self._raise_servo()
-                gcmd.respond_info(
+                self.gcode.respond_info(
                     "Failed to unload. Please pull filament {} out of the"
-                    " toolhead and selector, then use TR_RESUME to continue.".format(
-                        self.runout_lane
-                    )
+                    " toolhead and selector, then use TR_RESUME to "
+                    " continue.".format(self.runout_lane)
                 )
                 logging.warning(
                     "trad_rack: Failed to unload toolhead", exc_info=True
@@ -1885,11 +1974,13 @@ class TradRack:
         # find a new lane to use
         selector_already_loaded = False
         if self.runout_steps_done < 2:
-            lane = self._find_replacement_lane(self.runout_lane)
+            lane = self._find_replacement_lane(
+                self.runout_lane, check_runout_lane=check_runout_lane
+            )
             if lane is None:
                 runout_tool = self.tool_map[self.runout_lane]
                 assigned_lanes = self._get_assigned_lanes(runout_tool)
-                gcmd.respond_info(
+                self.gcode.respond_info(
                     "No replacement lane found for tool {tool}. The following"
                     " lanes are assigned to tool {tool}: {lanes}. Use"
                     " TR_LOAD_LANE LANE=&lt;lane index&gt; to load one of these"
@@ -1908,7 +1999,6 @@ class TradRack:
         # load toolhead
         self._load_toolhead(
             self.replacement_lane,
-            gcmd,
             selector_already_loaded=selector_already_loaded,
         )
         return True
@@ -1953,11 +2043,12 @@ class TradRack:
                 % (self.VARS_CALIB_BOWDEN_UNLOAD_LENGTH, length_stats)
             )
 
-    def _calibrate_selector(self, gcmd):
-        extra_travel = 1.0
+    def _calibrate_selector(self):
+        extra_travel_base = 1.0
+        extra_travel_per_lane = 0.3
 
         # prompt user to set the selector at lane 0
-        self._prompt_selector_calibration(0, gcmd)
+        self._prompt_selector_calibration(0)
         yield
 
         # measure position of lane 0 relative to endstop
@@ -1966,11 +2057,11 @@ class TradRack:
             .get_homing_info()
             .position_endstop
         )
-        max_travel = self.lane_positions[0] - pos_endstop + extra_travel
-        endstop_to_lane0 = self._measure_selector_to_endstop(max_travel, gcmd)
+        max_travel = self.lane_positions[0] - pos_endstop + extra_travel_base
+        endstop_to_lane0 = self._measure_selector_to_endstop(max_travel)
 
         # prompt user to set the selector at the last lane
-        self._prompt_selector_calibration(self.lane_count - 1, gcmd)
+        self._prompt_selector_calibration(self.lane_count - 1)
         yield
 
         # measure position of last lane relative to endstop
@@ -1978,19 +2069,16 @@ class TradRack:
             self.lane_positions[self.lane_count - 1]
             - self.lane_positions[0]
             + endstop_to_lane0
-            + extra_travel
+            + extra_travel_base
+            + (self.lane_count - 1) * extra_travel_per_lane
         )
-        endstop_to_last_lane = self._measure_selector_to_endstop(
-            max_travel, gcmd
-        )
+        endstop_to_last_lane = self._measure_selector_to_endstop(max_travel)
 
         # process calibration and set new lane positions
-        (
-            pos_endstop,
-            lane_spacing,
-            self.lane_positions,
-        ) = self.lane_position_manager.process_selector_calibration(
-            endstop_to_lane0, endstop_to_last_lane, 6
+        pos_endstop, lane_spacing, self.lane_positions = (
+            self.lane_position_manager.process_selector_calibration(
+                endstop_to_lane0, endstop_to_last_lane, 6
+            )
         )
 
         # round new config values
@@ -2015,7 +2103,7 @@ class TradRack:
         self.tr_toolhead.set_position(pos, homing_axes=(0,))
 
         # show results and prompt user to save config
-        gcmd.respond_info(
+        self.gcode.respond_info(
             "trad_rack: lane_spacing: {lane_spacing:.6f}\n{stepper}:"
             " position_min: {pos_min:.3f}\n{stepper}: position_endstop:"
             " {pos_endstop:.3f}\n{stepper}: position_max: {pos_max:.3f}\nMake"
@@ -2029,7 +2117,7 @@ class TradRack:
             )
         )
 
-    def _prompt_selector_calibration(self, lane, gcmd):
+    def _prompt_selector_calibration(self, lane):
         # go to lane
         if not self._is_selector_homed():
             self.cmd_TR_HOME(
@@ -2037,19 +2125,15 @@ class TradRack:
             )
         self._go_to_lane(lane)
 
-        # lower servo and turn the drive gear until filament is detected
-        self._lower_servo()
-        self.tr_toolhead.wait_moves()
-        gcmd.respond_info("Please insert filament in lane %d" % (lane))
-
         # disable selector motor
+        self.tr_toolhead.wait_moves()
         print_time = self.tr_toolhead.get_last_move_time()
         stepper_enable = self.printer.lookup_object("stepper_enable")
         enable = stepper_enable.lookup_enable(SELECTOR_STEPPER_NAME)
         enable.motor_disable(print_time)
 
         # load filament into the selector
-        self._load_selector(lane)
+        self._load_selector(lane, user_load=True)
 
         # extend filament past the sensor
         self._reset_fil_driver()
@@ -2066,14 +2150,14 @@ class TradRack:
 
         # prompt user to position selector
         self.tr_toolhead.wait_moves()
-        gcmd.respond_info(
+        self.gcode.respond_info(
             "To ensure that the filament paths of the lane module and selector"
             " are aligned, adjust the selector's position by hand until the"
             " filament can slide smoothly with very little resistance. Then use"
             " TR_NEXT to continue selector calibration."
         )
 
-    def _measure_selector_to_endstop(self, max_travel, gcmd):
+    def _measure_selector_to_endstop(self, max_travel):
         # set selector position
         print_time = self.tr_toolhead.get_last_move_time()
         pos = self.tr_toolhead.get_position()
@@ -2084,7 +2168,7 @@ class TradRack:
         enable.motor_enable(print_time)
 
         # unload selector into current lane
-        self._unload_selector(gcmd)
+        self._unload_selector()
 
         # clear current lane
         self.curr_lane = None
@@ -2126,35 +2210,29 @@ class TradRack:
         return max_travel - trigpos[0]
 
     # resume callbacks
-    def _resume_load_toolhead(self, gcmd):
-        # load any of the tool's assigned lanes to selector
-        selector_already_loaded = False
-        if self.retry_tool is not None:
-            replacement_lane = self._find_replacement_lane(self.retry_lane)
-            if replacement_lane is None:
-                raise self.gcode.error(
-                    "Failed to load filament into selector from any of the"
-                    " lanes assigned to tool {}".format(self.retry_tool)
-                )
-            self.next_lane = replacement_lane
-            selector_already_loaded = True
+    def _resume_load_toolhead(self):
+        if not self._is_next_toolchange_done():
+            selector_already_loaded = False
 
-        # retry loading lane
-        elif self.retry_lane is not None:
-            self._load_lane(self.retry_lane, gcmd, user_load=True)
+            # retry loading lane
+            if self.retry_lane is not None:
+                if self.retry_lane == self.next_lane:
+                    self._load_selector(self.retry_lane, user_load=True)
+                    selector_already_loaded = True
+                else:
+                    self._load_lane(self.retry_lane, user_load=True)
 
-        # load next filament into toolhead
-        self._load_toolhead(
-            self.next_lane,
-            gcmd,
-            selector_already_loaded=selector_already_loaded,
-        )
+            # load next filament into toolhead
+            self._load_toolhead(
+                self.next_lane,
+                tool=self.next_tool,
+                selector_already_loaded=selector_already_loaded,
+            )
 
         return False, "Toolhead loaded successfully. Resuming print"
 
     def _resume_check_condition(
         self,
-        gcmd,
         condition,
         action=None,
         resume_msg="Resuming print",
@@ -2164,19 +2242,31 @@ class TradRack:
             if action is not None:
                 action()
             return False, resume_msg
-        gcmd.respond_info(fail_msg)
+        self.gcode.respond_info(fail_msg)
         return True, None
 
-    def _resume_runout(self, gcmd):
-        if self._runout_replace_filament(gcmd):
+    def _resume_runout(self):
+        if self._runout_replace_filament():
             return False, "Toolhead loaded successfully. Resuming print"
         return True, None
 
     # other resume helper functions
-    def _set_up_resume(self, resume_type, resume_kwargs):
+    def _set_up_resume_and_pause(self, resume_type, resume_kwargs):
+        # clear the resume stack if the print is not paused
+        # (if the stack is not already empty but the print is not paused, then
+        # the user likely resumed the print manually without using TR_RESUME, so
+        # the existing resume setup is no longer relevant)
+        pause_resume = self.printer.lookup_object("pause_resume")
+        if not pause_resume.get_status(self.reactor.monotonic())["is_paused"]:
+            self.resume_stack.clear()
+
+        # add resume callback and arguments
         self.resume_stack.append(
             (self.resume_callbacks[resume_type], resume_kwargs)
         )
+
+        # pause the print
+        self._send_pause()
 
     def _unload_toolhead_and_resume(self):
         pause_resume = self.printer.lookup_object("pause_resume")
@@ -2209,6 +2299,9 @@ class TradRack:
         return {
             "curr_lane": self.curr_lane,
             "active_lane": self.active_lane,
+            "next_lane": self.next_lane,
+            "next_tool": self.next_tool,
+            "tool_map": self.tool_map,
             "selector_homed": self._is_selector_homed(),
         }
 
@@ -2342,14 +2435,12 @@ class TradRackKinematics:
         )
 
         # Setup boundary checks
-        (
-            self.sel_max_velocity,
-            self.sel_max_accel,
-        ) = toolhead.get_sel_max_velocity()
-        (
-            self.fil_max_velocity,
-            self.fil_max_accel,
-        ) = toolhead.get_fil_max_velocity()
+        self.sel_max_velocity, self.sel_max_accel = (
+            toolhead.get_sel_max_velocity()
+        )
+        self.fil_max_velocity, self.fil_max_accel = (
+            toolhead.get_fil_max_velocity()
+        )
         self.stepper_count = len(self.rails)
         self.limits = [(1.0, -1.0)] * self.stepper_count
         self.selector_min = selector_stepper_section.getfloat(
@@ -2653,7 +2744,7 @@ class TradRackExtruderSyncManager:
             prev_toolhead = self.toolhead
             external_toolhead = self.tr_toolhead
             self.reset_fil_driver()
-            new_pos = 0.0
+            new_pos = [0.0, 0.0, 0.0]
         elif sync_type == FIL_DRIVER_TO_EXTRUDER:
             steppers = self.fil_driver_rail.get_steppers()
             self._prev_trapq = self.tr_toolhead.get_trapq()
@@ -2663,6 +2754,8 @@ class TradRackExtruderSyncManager:
             prev_toolhead = self.tr_toolhead
             external_toolhead = self.toolhead
             new_pos = extruder.last_position
+            if not isinstance(new_pos, list):
+                new_pos = [new_pos, 0.0, 0.0]
         else:
             raise Exception("Invalid sync_type: %d" % sync_type)
 
@@ -2675,7 +2768,7 @@ class TradRackExtruderSyncManager:
                 stepper.set_stepper_kinematics(stepper_kinematics)
             )
             stepper.set_trapq(external_trapq)
-            stepper.set_position((new_pos, 0.0, 0.0))
+            stepper.set_position(new_pos)
             prev_toolhead.step_generators.remove(stepper.generate_steps)
             external_toolhead.register_step_generator(stepper.generate_steps)
         self.sync_state = sync_type


### PR DESCRIPTION
This change adds various small updates to the trad_rack module:
- Update description for TR_RESUME since it is no longer only used after a failed load or unload: Annex-Engineering/TradRack@f597dab
- Compatibility with changes to PrinterExtruder (from bleeding-edge-v2): #324
- Replace PAUSE_STATE with the pre-toolchange gcode state when pausing due to a failed toolchange: Annex-Engineering/TradRack@47ed7c5
  - (ensures RESUME brings the toolhead to the right place when it restores PAUSE_STATE, avoiding an error where the rest of the current layer is printed at the wrong height if the toolhead was moved during the toolchange command and the print file does not contain any z movements until the next layer)
- Make _load_lane() and _load_selector() less redundant: Annex-Engineering/TradRack@de3fe7a, Annex-Engineering/TradRack@6b319a7
- Get rid of retry_tool since _load_toolhead() can already check all the lanes assigned to next_tool: Annex-Engineering/TradRack@dbc7c29
- Skip toolchange resume callback if the next lane or tool is already loaded to the toolhead: Annex-Engineering/TradRack@bdb3312
- Reset next_lane and next_tool in TR_SET_ACTIVE_LANE if a matching lane was set to active: Annex-Engineering/TradRack@25e0473
- Add next_tool to status: Annex-Engineering/TradRack@9c4743d, Annex-Engineering/TradRack@c1d3230
- Don't add a gcmd (GCodeCommand) argument where it isn't needed: Annex-Engineering/TradRack@569c70d
- Catch more specific exceptions, replace instances of self.gcode.error with self.printer.command_error to be more consistent: Annex-Engineering/TradRack@949df75
- Fix issue from Annex-Engineering/TradRack@096f6a0 that could cause min_extrude_temp to be saved as tr_last_heater_target: Annex-Engineering/TradRack@1d4ef1a
- Initialize self.variables in init first: Annex-Engineering/TradRack@40f4ef3
- Scale extra travel for selector calibration homing moves based on lane count: Annex-Engineering/TradRack@92b2411
- Add option to _find_replacement_lane() to not check the runout lane: Annex-Engineering/TradRack@92b2411
  - (avoids an unnecessary attempted load if the lane is already known to be empty)
- _load_toolhead(): update lane and next_lane if the selector was loaded from a lane other than what was initially specified: Annex-Engineering/TradRack@ff09af8
- Use max distance from load_lane_time when loading the selector in TR_CALIBRATE_SELECTOR: Annex-Engineering/TradRack@f52f4f6
- Clear resume stack whenever a resume callback is set up while the print is not paused: Annex-Engineering/TradRack@28e497d
  - (any resume setup that the user bypassed by resuming the print without using TR_RESUME should now be dropped and not affect any future runs of TR_RESUME)
- Add next_lane and tool_map to status: Annex-Engineering/TradRack@d37c7ba
- If selector position is uncertain due to setting it via SET_ACTIVE_LANE, home during the next toolchange after unloading or when finding a replacement lane: Annex-Engineering/TradRack#9

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [x] ci is happy and green
