### PR TITLE
ci: apply ruff format to match precommit

### DIFF
--- a/.github/workflows/ci-static_analysis.yaml
+++ b/.github/workflows/ci-static_analysis.yaml
@@ -5,7 +5,10 @@ on: pull_request
 
 jobs:
   ruff:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
+      - uses: astral-sh/ruff-action@v1
+      - uses: astral-sh/ruff-action@v1
+        with:
+          args: "format --check"

--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -575,12 +575,15 @@ class PrinterConfig:
                 if config.fileconfig.has_option(section, option):
                     # They conflict only if they are not the same value
                     included_value = config.fileconfig.get(section, option)
-                    autosave_value = self.autosave.fileconfig.get(section, option)
+                    autosave_value = self.autosave.fileconfig.get(
+                        section, option
+                    )
                     if included_value != autosave_value:
                         msg = (
-                                "SAVE_CONFIG section '%s' option '%s' value '%s' conflicts "
-                                "with included value '%s' " % (section, option, autosave_value, included_value)
-                                )
+                            "SAVE_CONFIG section '%s' option '%s' value '%s' conflicts "
+                            "with included value '%s' "
+                            % (section, option, autosave_value, included_value)
+                        )
                         raise gcode.error(msg)
 
     cmd_SAVE_CONFIG_help = "Overwrite config file and restart"

--- a/klippy/extras/filament_motion_sensor.py
+++ b/klippy/extras/filament_motion_sensor.py
@@ -98,7 +98,11 @@ class EncoderSensor:
             "Always Fire Events: %s"
             % (
                 self.runout_helper.name,
-                ("enabled" if self.runout_helper.sensor_enabled else "disabled"),
+                (
+                    "enabled"
+                    if self.runout_helper.sensor_enabled
+                    else "disabled"
+                ),
                 "true" if self.runout_helper.filament_present else "false",
                 self.detection_length,
                 "true" if self.runout_helper.smart else "false",

--- a/klippy/extras/hall_filament_width_sensor.py
+++ b/klippy/extras/hall_filament_width_sensor.py
@@ -28,8 +28,12 @@ class HallFilamentWidthSensor:
         )
         self.measurement_delay = config.getfloat("measurement_delay", above=0.0)
         self.measurement_max_difference = config.getfloat("max_difference", 0.2)
-        self.max_diameter = self.nominal_filament_dia + self.measurement_max_difference
-        self.min_diameter = self.nominal_filament_dia - self.measurement_max_difference
+        self.max_diameter = (
+            self.nominal_filament_dia + self.measurement_max_difference
+        )
+        self.min_diameter = (
+            self.nominal_filament_dia - self.measurement_max_difference
+        )
         self.diameter = self.nominal_filament_dia
         self.is_active = config.getboolean("enable", False)
         self.runout_dia_min = config.getfloat("min_diameter", 1.0)
@@ -41,7 +45,9 @@ class HallFilamentWidthSensor:
             "use_current_dia_while_delay", False
         )
         runout_distance = config.getfloat("runout_distance", 0.0, minval=0.0)
-        self.check_on_print_start = config.getboolean("check_on_print_start", False)
+        self.check_on_print_start = config.getboolean(
+            "check_on_print_start", False
+        )
         # filament array [position, filamentWidth]
         self.filament_array = []
         self.lastFilamentWidthReading = 0
@@ -69,11 +75,21 @@ class HallFilamentWidthSensor:
         self.gcode.register_command(
             "RESET_FILAMENT_WIDTH_SENSOR", self.cmd_ClearFilamentArray
         )
-        self.gcode.register_command("DISABLE_FILAMENT_WIDTH_SENSOR", self.cmd_M406)
-        self.gcode.register_command("ENABLE_FILAMENT_WIDTH_SENSOR", self.cmd_M405)
-        self.gcode.register_command("QUERY_RAW_FILAMENT_WIDTH", self.cmd_Get_Raw_Values)
-        self.gcode.register_command("ENABLE_FILAMENT_WIDTH_LOG", self.cmd_log_enable)
-        self.gcode.register_command("DISABLE_FILAMENT_WIDTH_LOG", self.cmd_log_disable)
+        self.gcode.register_command(
+            "DISABLE_FILAMENT_WIDTH_SENSOR", self.cmd_M406
+        )
+        self.gcode.register_command(
+            "ENABLE_FILAMENT_WIDTH_SENSOR", self.cmd_M405
+        )
+        self.gcode.register_command(
+            "QUERY_RAW_FILAMENT_WIDTH", self.cmd_Get_Raw_Values
+        )
+        self.gcode.register_command(
+            "ENABLE_FILAMENT_WIDTH_LOG", self.cmd_log_enable
+        )
+        self.gcode.register_command(
+            "DISABLE_FILAMENT_WIDTH_LOG", self.cmd_log_disable
+        )
 
         self.runout_helper = filament_switch_sensor.RunoutHelper(
             config, self, runout_distance
@@ -101,7 +117,9 @@ class HallFilamentWidthSensor:
         ).estimated_print_time
 
         # Start extrude factor update timer
-        self.reactor.update_timer(self.extrude_factor_update_timer, self.reactor.NOW)
+        self.reactor.update_timer(
+            self.extrude_factor_update_timer, self.reactor.NOW
+        )
 
     def _handle_printing(self, *args):
         if not self.runout_helper.smart:
@@ -163,14 +181,18 @@ class HallFilamentWidthSensor:
                     [last_epos + self.measurement_delay, self.diameter]
                 )
                 if self.is_log:
-                    self.gcode.respond_info("Filament width:%.3f" % (self.diameter))
+                    self.gcode.respond_info(
+                        "Filament width:%.3f" % (self.diameter)
+                    )
 
         else:
             # add first item to array
             self.filament_array.append(
                 [self.measurement_delay + last_epos, self.diameter]
             )
-            self.firstExtruderUpdatePosition = self.measurement_delay + last_epos
+            self.firstExtruderUpdatePosition = (
+                self.measurement_delay + last_epos
+            )
 
     def extrude_factor_update_event(self, eventtime):
         # Update extrude factor
@@ -202,7 +224,9 @@ class HallFilamentWidthSensor:
                     self.filament_width >= self.min_diameter
                 ):
                     percentage = round(
-                        self.nominal_filament_dia**2 / self.filament_width**2 * 100
+                        self.nominal_filament_dia**2
+                        / self.filament_width**2
+                        * 100
                     )
                     self.gcode.run_script("M221 S" + str(percentage))
                 else:
@@ -307,7 +331,11 @@ class HallFilamentWidthSensor:
             "Always Fire Events: %s"
             % (
                 self.runout_helper.name,
-                ("enabled" if self.runout_helper.sensor_enabled else "disabled"),
+                (
+                    "enabled"
+                    if self.runout_helper.sensor_enabled
+                    else "disabled"
+                ),
                 "true" if self.runout_helper.filament_present else "false",
                 "true" if self.runout_helper.smart else "false",
                 "true" if self.runout_helper.always_fire_events else "false",
@@ -320,7 +348,9 @@ class HallFilamentWidthSensor:
     def get_status(self, eventtime=None):
         return {
             "Diameter": self.diameter,
-            "Raw": (self.lastFilamentWidthReading + self.lastFilamentWidthReading2),
+            "Raw": (
+                self.lastFilamentWidthReading + self.lastFilamentWidthReading2
+            ),
             "is_active": self.is_active,
             "check_on_print_start": bool(self.check_on_print_start),
         }

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -4,6 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
+
 class SafeZHoming:
     def __init__(self, config):
         self.printer = config.get_printer()
@@ -66,10 +67,14 @@ class SafeZHoming:
                 axis_order = "xy"
             for axis in axis_order:
                 if axis == "x" and need_x:
-                    g28_gcmd = self.gcode.create_gcode_command("G28", "G28", {"X": "0"})
+                    g28_gcmd = self.gcode.create_gcode_command(
+                        "G28", "G28", {"X": "0"}
+                    )
                     self.prev_G28(g28_gcmd)
                 elif axis == "y" and need_y:
-                    g28_gcmd = self.gcode.create_gcode_command("G28", "G28", {"Y": "0"})
+                    g28_gcmd = self.gcode.create_gcode_command(
+                        "G28", "G28", {"Y": "0"}
+                    )
                     self.prev_G28(g28_gcmd)
 
         # Home Z axis if necessary

--- a/klippy/extras/temperature_fan.py
+++ b/klippy/extras/temperature_fan.py
@@ -304,9 +304,9 @@ class ControlCurve:
 
     def temperature_callback(self, read_time, temp):
         def _interpolate(sbelow, above, temp):
-            return ((below[1] * (above[0] - temp)) + (above[1] * (temp - below[0]))) / (
-                above[0] - below[0]
-            )
+            return (
+                (below[1] * (above[0] - temp)) + (above[1] * (temp - below[0]))
+            ) / (above[0] - below[0])
 
         temp = self.smooth_temps(temp)
         if temp <= self.curve_table[0][0]:

--- a/klippy/kinematics/delta.py
+++ b/klippy/kinematics/delta.py
@@ -114,7 +114,7 @@ class DeltaKinematics:
 
         self.slow_xy2 = ratio_to_xy(SLOW_RATIO) ** 2
         self.very_slow_xy2 = ratio_to_xy(2.0 * SLOW_RATIO) ** 2
-        self.max_xy2 = print_radius ** 2
+        self.max_xy2 = print_radius**2
         max_xy = math.sqrt(self.max_xy2)
         logging.info(
             "Delta max build radius %.2fmm (moves slowed past %.2fmm"

--- a/scripts/requirements_dev.txt
+++ b/scripts/requirements_dev.txt
@@ -1,3 +1,3 @@
 # This file describes the Python virtualenv package requirements for
 # klipper CI checks and local development.
- ruff==0.4.5
+ruff==0.7.1


### PR DESCRIPTION
pre-commit runs ruff lint and ruff format checks, but ci only runs lint

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [x] ci is happy and green
