### PR TITLE
flash_usb: Wait for busnum file to exist when flashing with picoboot (#6690)

### DIFF
--- a/scripts/flash_usb.py
+++ b/scripts/flash_usb.py
@@ -221,7 +221,7 @@ def flash_picoboot(device, binfile, sudo):
     # We need one level up to get access to busnum/devnum files
     usbdir = os.path.dirname(devpath)
     enter_bootloader(device)
-    wait_path(usbdir)
+    wait_path(usbdir + "/busnum")
     with open(usbdir + "/busnum") as f:
         bus = f.read().strip()
     with open(usbdir + "/devnum") as f:


### PR DESCRIPTION
This solves an issue where the USB directory could exist, but the busnum file itself may not exist immediately. This was encountered when flashing a Pico connected to a Raspberry Pi 5.

Klipper PR: https://github.com/Klipper3d/klipper/pull/6690