### PR TITLE
ads1220: Add input_mux and vref options to ADS1220 sensor (#6713)

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -5371,13 +5371,30 @@ data_ready_pin:
 #gain: 128
 #   Valid gain values are 128, 64, 32, 16, 8, 4, 2, 1
 #   The default is 128
+#pga_bypass: False
+#   Disable the internal Programmable Gain Amplifier. If
+#   True the PGA will be disabled for gains 1, 2, and 4. The PGA is always
+#   enabled for gain settings 8 to 128, regardless of the pga_bypass setting.
+#   If AVSS is used as an input pga_bypass is forced to True.
+#   The default is False.
 #sample_rate: 660
 #   This chip supports two ranges of sample rates, Normal and Turbo. In turbo
-#   mode the chips c internal clock runs twice as fast and the SPI communication
+#   mode the chip's internal clock runs twice as fast and the SPI communication
 #   speed is also doubled.
 #   Normal sample rates: 20, 45, 90, 175, 330, 600, 1000
 #   Turbo sample rates: 40, 90, 180, 350, 660, 1200, 2000
 #   The default is 660
+#input_mux:
+#   Input multiplexer configuration, select a pair of pins to use. The first pin
+#   is the positive, AINP, and the second pin is the negative, AINN. Valid
+#   values are: 'AIN0_AIN1', 'AIN0_AIN2', 'AIN0_AIN3', 'AIN1_AIN2', 'AIN1_AIN3',
+#   'AIN2_AIN3', 'AIN1_AIN0', 'AIN3_AIN2', 'AIN0_AVSS', 'AIN1_AVSS', 'AIN2_AVSS'
+#   and 'AIN3_AVSS'. If AVSS is used the PGA is bypassed and the pga_bypass
+#   setting will be forced to True.
+#   The default is AIN0_AIN1.
+#vref:
+#   The selected voltage reference. Valid values are: 'internal', 'REF0', 'REF1'
+#   and 'analog_supply'. Default is 'internal'.
 ```
 
 

--- a/klippy/extras/ads1220.py
+++ b/klippy/extras/ads1220.py
@@ -65,8 +65,61 @@ class ADS1220:
         }
         self.sps_options = self.sps_normal.copy()
         self.sps_options.update(self.sps_turbo)
-        self.sps = config.getchoice("sps", self.sps_options, default="660")
+        self.sps = config.getchoice(
+            "sample_rate", self.sps_options, default="660"
+        )
         self.is_turbo = str(self.sps) in self.sps_turbo
+        # Input multiplexer: AINP and AINN
+        mux_options = {
+            "AIN0_AIN1": 0b0000,
+            "AIN0_AIN2": 0b0001,
+            "AIN0_AIN3": 0b0010,
+            "AIN1_AIN2": 0b0011,
+            "AIN1_AIN3": 0b0100,
+            "AIN2_AIN3": 0b0101,
+            "AIN1_AIN0": 0b0110,
+            "AIN3_AIN2": 0b0111,
+            "AIN0_AVSS": 0b1000,
+            "AIN1_AVSS": 0b1001,
+            "AIN2_AVSS": 0b1010,
+            "AIN3_AVSS": 0b1011,
+        }
+        self.mux = config.getchoice(
+            "input_mux", mux_options, default="AIN0_AIN1"
+        )
+        # PGA Bypass
+        self.pga_bypass = config.getboolean("pga_bypass", default=False)
+        # bypass PGA when AVSS is the negative input
+        force_pga_bypass = self.mux >= 0b1000
+        self.pga_bypass = force_pga_bypass or self.pga_bypass
+        # Voltage Reference
+        self.vref_options = {
+            "internal": 0b0,
+            "REF0": 0b01,
+            "REF1": 0b10,
+            "analog_supply": 0b11,
+        }
+        self.vref = config.getchoice(
+            "vref", self.vref_options, default="internal"
+        )
+        # check for conflict between REF1 and AIN0/AIN3
+        mux_conflict = [
+            0b0000,
+            0b0001,
+            0b0010,
+            0b0100,
+            0b0101,
+            0b0110,
+            0b0111,
+            0b1000,
+            0b1011,
+        ]
+        if self.vref == 0b10 and self.mux in mux_conflict:
+            raise config.error(
+                "ADS1220 config error: AIN0/REFP1 and AIN3/REFN1"
+                " cant be used as a voltage reference and"
+                " an input at the same time"
+            )
         # SPI Setup
         spi_speed = 512000 if self.is_turbo else 256000
         self.spi = bus.MCU_SPI_from_config(config, 1, default_speed=spi_speed)
@@ -196,8 +249,10 @@ class ADS1220:
         sps_list = self.sps_turbo if self.is_turbo else self.sps_normal
         data_rate = list(sps_list.keys()).index(str(self.sps))
         reg_values = [
-            (self.gain << 1),
+            (self.mux << 4) | (self.gain << 1) | int(self.pga_bypass),
             (data_rate << 5) | (mode << 3) | (continuous << 2),
+            (self.vref << 6),
+            0x0,
         ]
         self.write_reg(0x0, reg_values)
         # start measurements immediately
@@ -217,7 +272,7 @@ class ADS1220:
         write_command.extend(register_bytes)
         self.spi.spi_send(write_command)
         stored_val = self.read_reg(reg, len(register_bytes))
-        if register_bytes != stored_val:
+        if bytearray(register_bytes) != stored_val:
             raise self.printer.command_error(
                 "Failed to set ADS1220 register [0x%x] to %s: got %s. "
                 "This may be a connection problem (e.g. faulty wiring)"


### PR DESCRIPTION
* fix type comparison bug that stopped the sensor from initializing
* correct mismatch between docs and code for `sample_rate` (fixed to work same as hx71x)
* add input_mux, pga_bypass and vref options
* update configuration reference & fix typo

Klipper PR: https://github.com/Klipper3d/klipper/pull/6713