### PR TITLE
mcu: Only warn about mcu clock frequency if drift is more than 1%

### DIFF
--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -1217,9 +1217,10 @@ class MCU:
         systime = self._reactor.monotonic()
         get_clock = self._clocksync.get_clock
         calc_freq = get_clock(systime + 1) - get_clock(systime)
+        freq_diff = abs(mcu_freq - calc_freq)
         mcu_freq_mhz = int(mcu_freq / 1000000.0 + 0.5)
         calc_freq_mhz = int(calc_freq / 1000000.0 + 0.5)
-        if mcu_freq_mhz != calc_freq_mhz:
+        if freq_diff > mcu_freq * 0.01 and mcu_freq_mhz != calc_freq_mhz:
             pconfig = self._printer.lookup_object("configfile")
             msg = "MCU '%s' configured for %dMhz but running at %dMhz!" % (
                 self._name,


### PR DESCRIPTION
This reduces the chance of spurious MCU clock configuration warnings.

Klipper PR: https://github.com/Klipper3d/klipper/pull/6720
