### PR TITLE
fan.py : revert speed and deprecate off_below for UI compatibility

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,12 @@ All dates in this document are approximate.
 
 ## Changes
 
+yyyymmdd: The `off_below` parameter in fans config section is
+deprecated. It will be removed in the near future. Use
+[`min_power`](./Config_Reference.md#fans)
+instead. The `printer[fan object].speed` status will be replaced by
+`printer[fan object].value` and `printer[fan object].power`.
+
 20240430: The `adc_ignore_limits` parameter in the `[danger_options]`
 config section has been renamed to `temp_ignore_limits` and it now
 covers all possible temperature sensors.

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3318,6 +3318,9 @@ pin:
 #   input. In such a case, the PWM pin can be used normally, and e.g. a
 #   ground-switched FET(standard fan pin) can be used to control power to
 #   the fan.
+#off_below:
+#   These option is deprecated and should no longer be specified.
+#   Use `min_power` instead.
 ```
 
 ### [heated_fan]

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -156,9 +156,12 @@ The following information is available in
 [heater_fan some_name](Config_Reference.md#heater_fan) and
 [controller_fan some_name](Config_Reference.md#controller_fan)
 objects:
-- `speed`: The fan speed as a float between 0.0 and 1.0.
+- `value`: The fan speed value as a float between 0.0 and 1.0.
+- `power`: The fan power as a float between 0|`min_power` and 1.0|`max_power`.
 - `rpm`: The measured fan speed in rotations per minute if the fan has
   a tachometer_pin defined.
+deprecated objects (for UI compatibility only): 
+- `speed`: The fan speed as a float between 0.0 and `max_power`. 
 
 ## filament_switch_sensor
 

--- a/klippy/extras/fan.py
+++ b/klippy/extras/fan.py
@@ -13,6 +13,7 @@ class Fan:
         self.printer = config.get_printer()
         self.last_fan_value = 0.0
         self.last_fan_time = 0.0
+        self.last_pwm_value = 0.0
         # Read config
         self.kick_start_time = config.getfloat(
             "kick_start_time", 0.1, minval=0.0
@@ -23,6 +24,8 @@ class Fan:
         self.off_below = config.getfloat(
             "off_below", default=None, minval=0.0, maxval=1.0
         )
+        if self.off_below is not None:
+            config.deprecate("off_below")
 
         # handles switchover of variable
         # if new var is not set, and old var is, set new var to old var
@@ -111,6 +114,7 @@ class Fan:
             self.mcu_fan.set_pwm(print_time, self.max_power)
             print_time += self.kick_start_time
         self.mcu_fan.set_pwm(print_time, pwm_value)
+        self.last_pwm_value = pwm_value
         self.last_fan_time = print_time
         self.last_fan_value = value
 
@@ -126,7 +130,9 @@ class Fan:
     def get_status(self, eventtime):
         tachometer_status = self.tachometer.get_status(eventtime)
         return {
-            "speed": self.last_fan_value,
+            "power": self.last_pwm_value,
+            "value": self.last_fan_value,
+            "speed": self.last_fan_value * self.max_power,
             "rpm": tachometer_status["rpm"],
         }
 


### PR DESCRIPTION
The current PR :
- reverts and deprecates `speed` fan status to fix UI behavior and not break the API as discuss in https://github.com/fluidd-core/fluidd/issues/1457
- deprecates `off_below` 
- introduces `value` (real speed) and `power` status for future UI devs.

## Checklist

- [X] pr title makes sense
- [X] squashed to 1 commit
- [ ] added a test case if possible
- [X] if new feature, added to the readme
- [x] ci is happy and green
