### PR TITLE
requirements/bump numpy to latest v1.26

### DIFF
--- a/scripts/klippy-requirements.txt
+++ b/scripts/klippy-requirements.txt
@@ -9,4 +9,4 @@ greenlet==3.0.3 ; python_version >= '3.12'
 Jinja2==3.1.4
 python-can==3.3.4
 markupsafe==2.1.5
-numpy==1.25.2
+numpy==1.26.4


### PR DESCRIPTION
should fix https://github.com/DangerKlippers/danger-klipper/issues/422 and numpy + python3.12

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
