### PR TITLE
fan: add initial_speed property

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3321,6 +3321,9 @@ pin:
 #off_below:
 #   These option is deprecated and should no longer be specified.
 #   Use `min_power` instead.
+#initial_speed:
+#   Fan speed will be set to this value on startup if specified. Value
+#   is from 0.0 to 1.0.
 ```
 
 ### [heated_fan]
@@ -3368,6 +3371,7 @@ a shutdown_speed equal to max_power.
 #tachometer_ppr:
 #tachometer_poll_interval:
 #enable_pin:
+#initial_speed:
 #   See the "fan" section for a description of the above parameters.
 #heater: extruder
 #   Name of the config section defining the heater that this fan is

--- a/klippy/extras/fan.py
+++ b/klippy/extras/fan.py
@@ -26,6 +26,9 @@ class Fan:
         )
         if self.off_below is not None:
             config.deprecate("off_below")
+        self.initial_speed = config.getfloat(
+            "initial_speed", default=None, minval=0.0, maxval=1.0
+        )
 
         # handles switchover of variable
         # if new var is not set, and old var is, set new var to old var
@@ -83,6 +86,7 @@ class Fan:
         self.printer.register_event_handler(
             "gcode:request_restart", self._handle_request_restart
         )
+        self.printer.register_event_handler("klippy:ready", self._handle_ready)
 
     def get_mcu(self):
         return self.mcu_fan.get_mcu()
@@ -126,6 +130,10 @@ class Fan:
 
     def _handle_request_restart(self, print_time):
         self.set_speed(print_time, 0.0)
+
+    def _handle_ready(self):
+        if self.initial_speed:
+            self.set_speed_from_command(self.initial_speed)
 
     def get_status(self, eventtime):
         tachometer_status = self.tachometer.get_status(eventtime)


### PR DESCRIPTION
This property allows fans to have an initial speed on startup, without using delayed G-code.
The benefit is that you don't need delayed G-code anymore and can create fixed-speed `controller_fan`s that can't be controlled through your web interface or commands.

## Checklist

- [ ] pr title makes sense
- [ ] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
