### PR TITLE
Fixes docs relative links

### DIFF
--- a/docs/_klipper3d/mkdocs_hooks.py
+++ b/docs/_klipper3d/mkdocs_hooks.py
@@ -26,7 +26,7 @@ def transform(markdown: str, page, config, files):
         ) % 2
         if not in_code_block:
             line_out = line_out.replace(
-                "](../", f"]({config['repo_url']}blob/master/"
+                "](../", f"]({config['repo_url']}/blob/master/"
             )
             line_out = re.sub("\\\s*$", "<br>", line_out)
             # check that lists at level 0 are not indented


### PR DESCRIPTION
Fixes the docs relative links by adding the missing "/" between the repo url and "blob"

Fixes #435 

## Checklist

- [X] pr title makes sense
- [X] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [x] ci is happy and green
