### PR TITLE
Add invert_kinematics to hybrid_corexy and hybrid_corexz

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -704,6 +704,9 @@ parameters.
 ```
 [printer]
 kinematics: hybrid_corexy
+invert_kinematics: False
+# ⚠️ Some hybrid_corexy machines with dual carriages may need to
+#   invert the kinematics if the toolheads move in reverse
 max_z_velocity:
 #   This sets the maximum velocity (in mm/s) of movement along the z
 #   axis. The default is to use max_velocity for max_z_velocity.
@@ -738,6 +741,9 @@ parameters.
 ```
 [printer]
 kinematics: hybrid_corexz
+invert_kinematics: False
+# ⚠️ Some hybrid_corexy machines with dual carriages may need to
+#   invert the kinematics if the toolheads move in reverse
 max_z_velocity:
 #   This sets the maximum velocity (in mm/s) of movement along the z
 #   axis. The default is to use max_velocity for max_z_velocity.

--- a/klippy/kinematics/hybrid_corexz.py
+++ b/klippy/kinematics/hybrid_corexz.py
@@ -20,7 +20,15 @@ class HybridCoreXZKinematics:
         self.rails[2].get_endstops()[0][0].add_stepper(
             self.rails[0].get_steppers()[0]
         )
-        self.rails[0].setup_itersolve("corexz_stepper_alloc", b"-")
+
+        self.inverted = config.getboolean("invert_kinematics", False)
+        self.corexy_mode = (b"-", b"+")
+        if self.inverted:
+            self.corexy_mode = (b"+", b"-")
+
+        self.rails[0].setup_itersolve(
+            "corexz_stepper_alloc", self.corexy_mode[0]
+        )
         self.rails[1].setup_itersolve("cartesian_stepper_alloc", b"y")
         self.rails[2].setup_itersolve("cartesian_stepper_alloc", b"z")
         ranges = [r.get_range() for r in self.rails]
@@ -37,7 +45,9 @@ class HybridCoreXZKinematics:
             self.rails[2].get_endstops()[0][0].add_stepper(
                 self.rails[3].get_steppers()[0]
             )
-            self.rails[3].setup_itersolve("corexz_stepper_alloc", b"+")
+            self.rails[3].setup_itersolve(
+                "corexz_stepper_alloc", self.corexy_mode[1]
+            )
             dc_rail_0 = idex_modes.DualCarriagesRail(
                 self.rails[0], axis=0, active=True
             )
@@ -72,9 +82,15 @@ class HybridCoreXZKinematics:
             self.dc_module is not None
             and "PRIMARY" == self.dc_module.get_status()["carriage_1"]
         ):
-            return [pos[3] - pos[2], pos[1], pos[2]]
+            if self.inverted:
+                return [pos[3] + pos[2], pos[1], pos[2]]
+            else:
+                return [pos[3] - pos[2], pos[1], pos[2]]
         else:
-            return [pos[0] + pos[2], pos[1], pos[2]]
+            if self.inverted:
+                return [pos[0] - pos[2], pos[1], pos[2]]
+            else:
+                return [pos[0] + pos[2], pos[1], pos[2]]
 
     def update_limits(self, i, range):
         l, h = self.limits[i]


### PR DESCRIPTION
hybrid_corexy with dual_carriage (dual markforged kinematics)
 is used on several voron and voron-adjacent printers. In some
 hardware configurations, this requires stepper_x to be the
 right toolhead, and dual_carriage the left. I wasn't ok with
 t0 being on the right, so added an `invert_kinematics` config
 option to the kinematics, which flips the CoreXY math.

In later investigation, I found that Rat-Rig has also done this
 for the V-Core 4 (using a drop-in kinematics.ratrig_hybrid_corexy)
 so this also benefits them

I added the same to hybrid_corexz, assuming there may be some use
 to the few idex switchwires that exists

## Checklist

- [x] pr title makes sense
- [x] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
