### PR TITLE
Add TMC5160 short_conf configuration

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -4473,6 +4473,11 @@ sense_resistor:
 #   chip. This may be used to set custom motor parameters. The
 #   defaults for each parameter are next to the parameter name in the
 #   above list.
+#⚠️driver_s2vs_level: 6   # Short to Supply tolerance, from 4 to 15
+#⚠️driver_s2g_level: 6    # Short to Ground tolerance, from 2 to 15
+#⚠️driver_shortdelay: 0   # Short trigger delay, 0=750ns, 1=1500ns
+#⚠️driver_short_filter: 1 
+#   Short filtering bandwidth. 0=100ns, 1=1us (Default), 2=2us, 3=3us
 #diag0_pin:
 #diag1_pin:
 #   The micro-controller pin attached to one of the DIAG lines of the

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -77,6 +77,8 @@ class FieldHelper:
             )
         else:
             val = config.getint(config_name, default, minval=0, maxval=maxval)
+        if default is None and val is None:
+            return
         return self.set_field(field_name, val)
 
     def pretty_format(self, reg_name, reg_value):

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -123,6 +123,12 @@ Fields["DRV_CONF"] = {
     "drvstrength": 0x03 << 18,
     "filt_isense": 0x03 << 20,
 }
+Fields["SHORT_CONF"] = {
+    "s2vs_level": 0x0F << 0,
+    "s2g_level": 0x0F << 8,
+    "short_filter": 0x03 << 16,
+    "shortdelay": 0x01 << 18,
+}
 Fields["DRV_STATUS"] = {
     "sg_result": 0x3FF << 0,
     "s2vsa": 0x01 << 12,
@@ -375,6 +381,22 @@ class TMC5160:
         set_config_field(config, "bbmclks", 4)
         set_config_field(config, "bbmtime", 0)
         set_config_field(config, "filt_isense", 0)
+        #   SHORT_CONF, being write only we can't partially update
+        # TODO: add a hook to read OTP on connect to get the defaults here
+        if config.getint("driver_s2vs_level", None, 4, 15) and config.getint(
+            "driver_s2g_level", None, 2, 15
+        ):
+            set_config_field(config, "s2vs_level", 6)
+            set_config_field(config, "s2g_level", 6)
+            set_config_field(config, "short_filter", 1)
+            set_config_field(config, "shortdelay", 0)
+        elif any(
+            config.get("driver_%s" % field, None, False)
+            for field in Fields["SHORT_CONF"].keys()
+        ):
+            raise config.error(
+                "driver_s2vs_level and driver_s2g_level are required to update short_conf"
+            )
         #   IHOLDIRUN
         set_config_field(config, "iholddelay", 6)
         #   PWMCONF


### PR DESCRIPTION
At 48v, the default s2vs/s2g_level of 6 is too low in some cases. This can be seen on some large printers where you may get spurious ShortToGround or ShortToSupply

Because s2vs/s2g_level are write-only, we must configure the full register as we can't read the existing values to update. As they are adjustable from OTP, we can't assume a default of `6`, and I don't want to change behavior for existing configurations.

I prefer having the individual fields with the config checks over a single opaque integer value such as `driver_short_conf: 331278` (which sets s2vs and s2g to 12, other values to defaults). 

My future goal is to add a `connect` time hook to tmc driver initialization, allowing reading the OTP_READ values to populate these defaults (Setting the OTP bit `otp_s2_level` raises the detection levels from 6 to 12, and is intended to be factory set for high-power usage). This would require rewriting the klippy-side TMC register values to be stored individually, allowing sentinels for the OTP-dependent fields to be overwritten during connect.

## Checklist

- [ ] pr title makes sense
- [ ] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
