### PR TITLE
Add calibration fields to MPC_SET

### DIFF
--- a/docs/MPC.md
+++ b/docs/MPC.md
@@ -382,6 +382,12 @@ MPC_CALIBRATE HEATER=heater_bed FAN_BREAKPOINTS=5
 
 These calibrated model parameters need to be saved to the _SAVE_CONFIG_ block manually or by using the `SAVE_CONFIG` command.
 
+## Updating calibration parameters at runtime
+
+Similar to [`SET_HEATER_PID`](G-Codes.md#set_heater_pid), you can update your MPC calibration profile at runtime.
+
+`MPC_SET HEATER=<heater_name> [BLOCK_HEAT_CAPACITY=0.0] [SENSOR_RESPONSIVENESS=0.0] [AMBIENT_TRANSFER=0.0] [FAN_AMBIENT_TRANSFER=0.01,0.02,0.03]`
+
 # BACKGROUND
 
 ## MPC Algorithm

--- a/klippy/extras/control_mpc.py
+++ b/klippy/extras/control_mpc.py
@@ -64,6 +64,28 @@ class ControlMPC:
             "FILAMENT_HEAT_CAPACITY", self.const_filament_heat_capacity
         )
 
+        self.const_block_heat_capacity = gcmd.get_float(
+            "BLOCK_HEAT_CAPACITY", self.const_block_heat_capacity
+        )
+        self.const_sensor_responsiveness = gcmd.get_float(
+            "SENSOR_RESPONSIVENESS", self.const_sensor_responsiveness
+        )
+        self.const_ambient_transfer = gcmd.get_float(
+            "AMBIENT_TRANSFER", self.const_ambient_transfer
+        )
+
+        if gcmd.get("FAN_AMBIENT_TRANSFER", None):
+            try:
+                self.const_fan_ambient_transfer = [
+                    float(v)
+                    for v in gcmd.get("FAN_AMBIENT_TRANSFER").split(",")
+                ]
+            except ValueError:
+                raise gcmd.error(
+                    f"Error on '{gcmd._commandline}': unable to parse FAN_AMBIENT_TRANSFER\n"
+                    "Must be a comma-separated list of values ('0.05,0.07,0.08')"
+                )
+
         temp = gcmd.get("FILAMENT_TEMP", None)
         if temp is not None:
             temp = temp.lower().strip()


### PR DESCRIPTION
This allows for changing your MPC calibration values on the fly.

I need to update my MPC values while docked to offset for what is effectively a heatsink as a nozzle rest.

## Checklist

- [ ] pr title makes sense
- [ ] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
