### PR TITLE
Fix the canserial query response

### DIFF
--- a/scripts/canbus_query.py
+++ b/scripts/canbus_query.py
@@ -22,7 +22,7 @@ RESP_DANGER_NODEID = 0x07
 AppNames = {
     CMD_SET_KLIPPER_NODEID: "Klipper",
     RESP_DANGER_NODEID: "Danger-Klipper",
-    CMD_SET_CANBOOT_NODEID: "CanBoot",
+    CMD_SET_CANBOOT_NODEID: "Katapult",
 }
 
 

--- a/src/generic/canserial.c
+++ b/src/generic/canserial.c
@@ -117,7 +117,7 @@ console_sendf(const struct command_encoder *ce, va_list args)
 #define CANBUS_CMD_REQUEST_BOOTLOADER 0x02
 
 #define CANBUS_RESP_KLIPPER_NODEID 0x01
-#define CANBUS_RESP_DANGER_NODEID 0x11
+#define CANBUS_RESP_DANGER_NODEID 0x07
 #define CANBUS_RESP_NEED_NODEID 0x20
 #define CANBUS_RESP_HAVE_NODEID 0x21
 


### PR DESCRIPTION
I was accidentally sending the CanBoot/Katapult app_id 0x11 instead of the Danger app_id 0x07

Additionally, its Katapult now not CanBoot

Fixes #445 

## Checklist

- [ ] pr title makes sense
- [ ] squashed to 1 commit
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
